### PR TITLE
webpのループ回数指定不具合の修正

### DIFF
--- a/product/src/app/process/process-export-image.ts
+++ b/product/src/app/process/process-export-image.ts
@@ -450,15 +450,7 @@ export class ProcessExportImage {
 
       if (this.animationOptionData.noLoop === false) {
         options.push(`-loop`);
-        let loopNum = this.animationOptionData.loop - 1;
-
-        // ループ回数が0だと無限ループになる
-        // ループ回数が1だと2ループになる
-        // 一回きりの再生ができない・・・！
-        if (loopNum === 0) {
-          loopNum = 1; // バグ
-        }
-        options.push(loopNum + '');
+        options.push(this.animationOptionData.loop + '');
       }
 
       options.push(`-o`);


### PR DESCRIPTION
webpのループ回数指定不具合が最新の実行バイナリで直っていたため、コード上で無限ループにならないように調整していた部分を削除しました。

Windows・macOSともに1-3ループの挙動を確認済み。