### PR TITLE
LINE用保存で処理が固まる問題を修正

### DIFF
--- a/product/dist-config/main-src/file.js
+++ b/product/dist-config/main-src/file.js
@@ -286,7 +286,6 @@ var File = /** @class */ (function () {
                     }
                     else {
                         _this.generateCancelPNG = true;
-                        console.log(result);
                         return Promise.resolve();
                     }
                 });
@@ -297,7 +296,6 @@ var File = /** @class */ (function () {
             // WebP書き出しが有効になっている場合
             if (_this.animationOptionData.enabledExportWebp === true) {
                 return _this.openSaveDialog('webp', _this.mainWindow, _this.defaultSaveDirectory).then(function (result) {
-                    console.log(result);
                     if (result.result) {
                         _this.selectedWebPPath = result.filePath;
                         return _this._generateWebp(result.filePath);
@@ -309,24 +307,15 @@ var File = /** @class */ (function () {
                     }
                 });
             }
+            else {
+                return Promise.resolve();
+            }
         })
             .then(function () {
             console.log('::start-export-html::');
             // APNGとWebP画像の両方書き出しが有効になっている場合
-            if (_this.animationOptionData.enabledExportHtml === true) {
-                // 	画像ファイルが保存されているか。
-                if (!_this._imageFileSaved()) {
-                    _this.generateCancelHTML = true;
-                    var dialogOption = {
-                        type: 'info',
-                        buttons: ['OK'],
-                        title: _this.localeData.APP_NAME,
-                        message: null,
-                        detail: '画像ファイルが保存されなかったため、HTMLの保存を行いませんでした。'
-                    };
-                    electron_1.dialog.showMessageBox(_this.mainWindow, dialogOption);
-                    return Promise.resolve();
-                }
+            if (_this.animationOptionData.enabledExportHtml === true &&
+                _this._imageFileSaved()) {
                 _this.errorCode = error_type_1.ErrorType.HTML_ERROR;
                 return _this.openSaveDialog('html', _this.mainWindow, _this.defaultSaveDirectory).then(function (result) {
                     if (result.result) {
@@ -336,14 +325,13 @@ var File = /** @class */ (function () {
                     }
                     else {
                         _this.generateCancelHTML = true;
-                        console.log(result);
                         return Promise.resolve();
                     }
                 });
             }
         })
             .then(function () {
-            console.log('::start-export-wepb::');
+            console.log('::finish::');
             if (!((_this.animationOptionData.enabledExportHtml &&
                 !_this.generateCancelHTML) ||
                 _this._enableExportApng() ||
@@ -606,8 +594,8 @@ var File = /** @class */ (function () {
                                     type: 'info',
                                     buttons: ['OK'],
                                     title: _this.localeData.APP_NAME,
-                                    message: null,
-                                    detail: message + '\n\n' + detailMessage
+                                    message: message,
+                                    detail: detailMessage
                                 };
                                 electron_1.dialog.showMessageBox(_this.mainWindow, dialogOption);
                             }

--- a/product/dist-config/main-src/main.js
+++ b/product/dist-config/main-src/main.js
@@ -95,6 +95,7 @@ function openFileDialog(event) {
 }
 ipcMain.on(ipc_id_1.IpcId.SET_CONFIG_DATA, function (event, localeData, appConfig) {
     console.log(ipc_id_1.IpcId.SET_CONFIG_DATA + " to " + localeData);
+    fileService.setLocaleData(localeData);
     fileService.setDefaultFileName(localeData.defaultFileName);
     mainWindow.setTitle(localeData.APP_NAME);
     var menu = new application_menu_1.ApplicationMenu(appConfig, localeData);

--- a/product/main-src/file.ts
+++ b/product/main-src/file.ts
@@ -877,7 +877,7 @@ export default class File {
                     type: 'info',
                     buttons: ['OK'],
                     title: this.localeData.APP_NAME,
-                    message,
+                    message: message,
                     detail: detailMessage
                   };
                   dialog.showMessageBox(this.mainWindow, dialogOption);

--- a/product/main-src/file.ts
+++ b/product/main-src/file.ts
@@ -877,8 +877,8 @@ export default class File {
                     type: 'info',
                     buttons: ['OK'],
                     title: this.localeData.APP_NAME,
-                    message: null,
-                    detail: message + '\n\n' + detailMessage
+                    message,
+                    detail: detailMessage
                   };
                   dialog.showMessageBox(this.mainWindow, dialogOption);
                 }

--- a/product/main-src/main.ts
+++ b/product/main-src/main.ts
@@ -127,6 +127,7 @@ ipcMain.on(
   (event, localeData: ILocaleData, appConfig: AppConfig) => {
     console.log(`${IpcId.SET_CONFIG_DATA} to ${localeData}`);
 
+    fileService.setLocaleData(localeData);
     fileService.setDefaultFileName(localeData.defaultFileName);
     mainWindow.setTitle(localeData.APP_NAME);
 


### PR DESCRIPTION
#12 

## 修正の概要

- レンダラー側からメインプロセス側にローカライズ情報を引き渡す処理が欠落していたので追加しました
- LINEスタンプの保存時にチェックエラーがある場合ダイアログを表示していますが、`message`に`null`を渡しておりエラーになっていたため修正しました

## 確認いただきたい事項

- 残件として記載いただいていた「ファイル保存キャンセル時のエラーハンドリング（キャンセル時に動作が停止してしまう）」はこの修正でカバーされているでしょうか？
  - LINE用保存ではキャンセルで止まらなくなることを確認しました
  - web用保存では修正前の状態で事象を確認できませんでした→再現条件などありましたら教えてください

## スクリーンショット

修正前
<img width="899" alt="スクリーンショット 2022-01-25 19 01 27" src="https://user-images.githubusercontent.com/59550270/150957570-fa276a2a-1656-43aa-98e7-7469bc4cd303.png">

修正後
<img width="1013" alt="スクリーンショット 2022-01-25 19 03 56" src="https://user-images.githubusercontent.com/59550270/150957592-a62bddee-ece7-41bb-a56a-8806662ba32b.png">

