### PR TITLE
画像選択・再選択を複数回行うと動作しない問題の修正

### DIFF
--- a/product/dist-config/main-src/main.js
+++ b/product/dist-config/main-src/main.js
@@ -67,7 +67,7 @@ var openFileDialog = function (event) {
         .showOpenDialog(mainWindow, dialogOption)
         .then(function (files) {
         event.sender.send(ipc_id_1.IpcId.SELECTED_OPEN_IMAGES, files);
-    })["catch"](function () {
+    })["finally"](function () {
         event.sender.send(ipc_id_1.IpcId.UNLOCK_SELECT_UI);
     });
 };

--- a/product/main-src/main.ts
+++ b/product/main-src/main.ts
@@ -90,7 +90,7 @@ const openFileDialog = (event: IpcMainEvent) => {
     .then((files) => {
       event.sender.send(IpcId.SELECTED_OPEN_IMAGES, files);
     })
-    .catch(() => {
+    .finally(() => {
       event.sender.send(IpcId.UNLOCK_SELECT_UI);
     });
 };

--- a/product/src/app/components/app/app.ts
+++ b/product/src/app/components/app/app.ts
@@ -79,11 +79,15 @@ export class AppComponent implements OnInit, AfterViewInit {
 
     this.ipcService.sendConfigData(this.localeData);
 
-    // 	保存先の指定返却
-    this.ipcService.selectedOpenImages().then((list) => {
+    // 保存先の指定返却
+    this.ipcService.onSelectedOpenImages((list) => {
+      if (!list.length) {
+        return;
+      }
       this.selectedImages(list);
     });
-    this.ipcService.unlockSelectUi().then(() => {
+    // UIロックの解除
+    this.ipcService.onUnlockSelectUi(() => {
       this.unlockSelectUi();
     });
   }

--- a/product/src/app/process/ServiceEvent.ts
+++ b/product/src/app/process/ServiceEvent.ts
@@ -1,0 +1,21 @@
+type Handler<T> = (param: T) => void;
+
+/** 独自のイベントを管理するクラス */
+export class ServiceEvent<T> {
+  private handlers: Handler<T>[] = [];
+
+  /** イベントを発行します */
+  fire(param: T) {
+    this.handlers.forEach((handler) => handler(param));
+  }
+
+  /** リスナーを登録します */
+  add(handler: Handler<T>) {
+    this.handlers = [...this.handlers.filter((h) => handler !== h), handler];
+  }
+
+  /** 登録済みのリスナーを削除します */
+  remove(handler: Handler<T>) {
+    this.handlers = this.handlers.filter((h) => handler !== h);
+  }
+}


### PR DESCRIPTION
#17 の対応を行いました

■ 変更概要
- IpcServiceクラスに簡易的なイベント機能を追加しました
- 画像選択完了時のイベント(selectedOpenImages)とUIロック解除要求のイベント(unlockSelectUi)をPromiseを使う方式から追加したイベント機能を使う方式に変更しました

下記操作で正しく動作することを確認しています：
- 画像の選択→再選択→再選択
- 画像の選択→再選択→開くダイアログでキャンセル→再選択