### PR TITLE
移行でデグレした箇所の修正

### DIFF
--- a/product/src/app/components/app/app.html
+++ b/product/src/app/components/app/app.html
@@ -13,10 +13,10 @@
           #optionSelecter
           (change)="handlePresetChange(optionSelecter.value)"
         >
-          <option value="0" [selected]="presetMode === PresetType.LINE">
+          <option [value]="PresetType.LINE" [selected]="presetMode === PresetType.LINE">
             {{ localeData.PROP_useItemLine }}
           </option>
-          <option value="1" [selected]="presetMode === PresetType.WEB">
+          <option [value]="PresetType.WEB" [selected]="presetMode === PresetType.WEB">
             {{ localeData.PROP_useItemWeb }}
           </option>
         </select>

--- a/product/src/app/components/app/checkImagePxSizeMatched.ts
+++ b/product/src/app/components/app/checkImagePxSizeMatched.ts
@@ -50,6 +50,6 @@ export const checkImagePxSizeMatched = async (
   );
   return {
     baseSize: firstSize,
-    errorItem: items[mismatchedIndex]
+    errorItem: restItems[mismatchedIndex]
   };
 };

--- a/product/src/app/process/ipc.service.ts
+++ b/product/src/app/process/ipc.service.ts
@@ -86,8 +86,8 @@ export default class IpcService {
         itemList,
         animationOptionData
       );
-      if (result.result) {
-        console.log(result);
+      console.log(`exec finished: result=${result}`);
+      if (result) {
         resolve();
       } else {
         reject();


### PR DESCRIPTION
v2.2移行作業で発生していた不具合・デグレをまとめて修正しました

■ 変更概要
- プリセットの切り替えが動作していなかったので修正しました
- 保存時にコンソールにzone.jsのエラーが表示されていた問題を修正しました
- 連番画像のサイズ が不一致の際に表示されるエラーのファイル名がひとつずれていた（N番目が不一致なのにN-1番目のファイル名が表示される）問題を修正しました
