### PR TITLE
プロセス間通信の非同期化と型情報付与

### DIFF
--- a/product/common-src/ipc-id.ts
+++ b/product/common-src/ipc-id.ts
@@ -1,11 +1,48 @@
+import { IpcMain, IpcMainEvent, IpcMainInvokeEvent } from 'electron';
+import { isCryptoKey } from 'util/types';
+import { AnimationImageOptions } from './data/animation-image-option';
+import { ImageData } from './data/image-data';
+import { ILocaleData } from './i18n/locale-data.interface';
+
+// プロセス間通信のchannel名の定数定義です
 export const IpcId = {
   OPEN_FILE_DIALOG: 'open-file-dialog',
   OPEN_SAVE_DIALOG: 'open-save-dialog',
   SET_CONFIG_DATA: 'set-config-data',
-  SHOW_ERROR_MESSAGE: 'show-error-message',
   SEND_ERROR: 'send-error',
   EXEC_IMAGE_EXPORT_PROCESS: 'exec-image-export-process',
-  SELECTED_OPEN_IMAGES: 'selected-open-images',
-  UNLOCK_SELECT_UI: 'unlock-select-ui',
-  OPEN_EXTERNAL_BROWSER: 'open-external-browser',
+  OPEN_EXTERNAL_BROWSER: 'open-external-browser'
 } as const;
+
+// UI→メイン方向にinvokeで起動する処理の型定義
+// この処理はmain-src/main.tsで実装します
+interface IpcInvokeFuncs {
+  [IpcId.OPEN_FILE_DIALOG]: () => Promise<string[]>;
+  [IpcId.OPEN_SAVE_DIALOG]: () => Promise<void>;
+  [IpcId.SET_CONFIG_DATA]: (local: ILocaleData) => Promise<void>;
+  [IpcId.SEND_ERROR]: (
+    version: string,
+    code: string,
+    category: string,
+    title: string,
+    detail: string
+  ) => Promise<void>;
+  [IpcId.EXEC_IMAGE_EXPORT_PROCESS]: (
+    version: string,
+    itemList: ImageData[],
+    animationOptionData: AnimationImageOptions
+  ) => Promise<void>;
+  [IpcId.OPEN_EXTERNAL_BROWSER]: (url: string) => Promise<void>;
+}
+
+// IpcRenderer.invokeの型定義
+export type IpcInvoke = <K extends typeof IpcId[keyof typeof IpcId]>(
+  channel: K,
+  ...params: Parameters<IpcInvokeFuncs[K]>
+) => ReturnType<IpcInvokeFuncs[K]>;
+
+// IpcMain.handleの型定義
+export type IpcMainHandled = <K extends typeof IpcId[keyof typeof IpcId]>(
+  channel: K,
+  listener: (event: IpcMainInvokeEvent, ...params: Parameters<IpcInvokeFuncs[K]>) => ReturnType<IpcInvokeFuncs[K]>
+) => void;

--- a/product/dist-config/common-src/ipc-id.js
+++ b/product/dist-config/common-src/ipc-id.js
@@ -1,14 +1,12 @@
 "use strict";
 exports.__esModule = true;
 exports.IpcId = void 0;
+// プロセス間通信のchannel名の定数定義です
 exports.IpcId = {
     OPEN_FILE_DIALOG: 'open-file-dialog',
     OPEN_SAVE_DIALOG: 'open-save-dialog',
     SET_CONFIG_DATA: 'set-config-data',
-    SHOW_ERROR_MESSAGE: 'show-error-message',
     SEND_ERROR: 'send-error',
     EXEC_IMAGE_EXPORT_PROCESS: 'exec-image-export-process',
-    SELECTED_OPEN_IMAGES: 'selected-open-images',
-    UNLOCK_SELECT_UI: 'unlock-select-ui',
     OPEN_EXTERNAL_BROWSER: 'open-external-browser'
 };

--- a/product/dist-config/main-src/main.js
+++ b/product/dist-config/main-src/main.js
@@ -1,4 +1,40 @@
 "use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 exports.__esModule = true;
 var electron_1 = require("electron");
 var path = require("path");
@@ -16,6 +52,10 @@ var errorMessage = new error_message_1.ErrorMessage();
 var fileService;
 // メインウィンドウ
 var mainWindow;
+// 型定義付きのイベントハンドラー： UI側からのinvokeを受け取って処理します
+var handle = function (channel, listener) {
+    electron_1.ipcMain.handle(channel, listener);
+};
 var createWindow = function () {
     // メインウィンドウを作成します
     mainWindow = new electron_1.BrowserWindow({
@@ -55,22 +95,6 @@ var createWindow = function () {
         });
     }
 };
-var openFileDialog = function (event) {
-    var dialogOption = {
-        properties: ['openFile', 'multiSelections'],
-        filters: [{ name: 'Images', extensions: ['png'] }]
-    };
-    if (!mainWindow) {
-        return;
-    }
-    electron_1.dialog
-        .showOpenDialog(mainWindow, dialogOption)
-        .then(function (files) {
-        event.sender.send(ipc_id_1.IpcId.SELECTED_OPEN_IMAGES, files);
-    })["finally"](function () {
-        event.sender.send(ipc_id_1.IpcId.UNLOCK_SELECT_UI);
-    });
-};
 //  初期化が完了した時の処理
 electron_1.app.on('ready', createWindow);
 // 全てのウィンドウが閉じたときの処理
@@ -94,44 +118,77 @@ electron_1.app.on('will-quit', function () {
     mainWindow = undefined;
     fileService = undefined;
 });
-electron_1.ipcMain.on(ipc_id_1.IpcId.OPEN_FILE_DIALOG, openFileDialog);
-electron_1.ipcMain.on(ipc_id_1.IpcId.SET_CONFIG_DATA, function (event, localeData) {
-    console.log("".concat(ipc_id_1.IpcId.SET_CONFIG_DATA, " to ").concat(localeData));
-    if (!mainWindow) {
-        return;
-    }
-    fileService = new file_1["default"](mainWindow, localeData, electron_1.app.getAppPath(), sendError, errorMessage, new SaveDialog_1.SaveDialog(mainWindow, electron_1.app.getPath('desktop'), localeData.defaultFileName));
-    mainWindow.setTitle(localeData.APP_NAME);
-    var menu = new application_menu_1.ApplicationMenu(localeData);
-    menu.createMenu(electron_1.app);
-});
-electron_1.ipcMain.on(ipc_id_1.IpcId.SHOW_ERROR_MESSAGE, function (event, errorCode, inquiryCode, errorDetail, errorStack, appName) {
-    if (!mainWindow) {
-        return;
-    }
-    errorMessage.showErrorMessage(errorCode, inquiryCode, errorDetail, errorStack, appName, mainWindow);
-});
-electron_1.ipcMain.on(ipc_id_1.IpcId.SEND_ERROR, function (event, version, code, category, title, detail) {
-    sendError.exec(version, code, category, title, detail);
-});
-electron_1.ipcMain.on(ipc_id_1.IpcId.EXEC_IMAGE_EXPORT_PROCESS, function (event, version, itemList, animationOptionData) {
-    console.log(version, itemList, animationOptionData);
-    if (!fileService) {
-        console.error('fileService has not inited');
-        event.returnValue = false;
-        return;
-    }
-    fileService
-        .exec(electron_1.app.getPath('temp'), version, itemList, animationOptionData)
-        .then(function () {
-        console.log("returnValue:true");
-        event.returnValue = true;
-    })["catch"](function () {
-        // 失敗時の処理
-        console.log("returnValue:false");
-        event.returnValue = false;
+// オープンダイアログ = 画像を選択
+handle(ipc_id_1.IpcId.OPEN_FILE_DIALOG, function () { return __awaiter(void 0, void 0, void 0, function () {
+    var dialogOption, result;
+    return __generator(this, function (_a) {
+        switch (_a.label) {
+            case 0:
+                dialogOption = {
+                    properties: ['openFile', 'multiSelections'],
+                    filters: [{ name: 'Images', extensions: ['png'] }]
+                };
+                if (!mainWindow) {
+                    return [2 /*return*/, []];
+                }
+                return [4 /*yield*/, electron_1.dialog.showOpenDialog(mainWindow, dialogOption)];
+            case 1:
+                result = _a.sent();
+                return [2 /*return*/, result.filePaths];
+        }
     });
-});
-electron_1.ipcMain.on(ipc_id_1.IpcId.OPEN_EXTERNAL_BROWSER, function (event, pageUrl) {
-    electron_1.shell.openExternal(pageUrl);
-});
+}); });
+// UI→メインに設定を共有する
+handle(ipc_id_1.IpcId.SET_CONFIG_DATA, function (event, localeData) { return __awaiter(void 0, void 0, void 0, function () {
+    var menu;
+    return __generator(this, function (_a) {
+        console.log("".concat(ipc_id_1.IpcId.SET_CONFIG_DATA, " to ").concat(localeData));
+        if (!mainWindow) {
+            return [2 /*return*/];
+        }
+        fileService = new file_1["default"](mainWindow, localeData, electron_1.app.getAppPath(), sendError, errorMessage, new SaveDialog_1.SaveDialog(mainWindow, electron_1.app.getPath('desktop'), localeData.defaultFileName));
+        mainWindow.setTitle(localeData.APP_NAME);
+        menu = new application_menu_1.ApplicationMenu(localeData);
+        menu.createMenu(electron_1.app);
+        return [2 /*return*/];
+    });
+}); });
+// エラーを送信
+handle(ipc_id_1.IpcId.SEND_ERROR, function (event, version, code, category, title, detail) { return __awaiter(void 0, void 0, void 0, function () {
+    return __generator(this, function (_a) {
+        sendError.exec(version, code, category, title, detail);
+        return [2 /*return*/];
+    });
+}); });
+// 保存場所を聞いて保存処理を実行
+handle(ipc_id_1.IpcId.EXEC_IMAGE_EXPORT_PROCESS, function (event, version, itemList, animationOptionData) { return __awaiter(void 0, void 0, void 0, function () {
+    return __generator(this, function (_a) {
+        console.log(version, itemList, animationOptionData);
+        if (!fileService) {
+            console.error('fileService has not inited');
+            event.returnValue = false;
+            return [2 /*return*/];
+        }
+        return [2 /*return*/, fileService
+                .exec(electron_1.app.getPath('temp'), version, itemList, animationOptionData)
+                .then(function () {
+                console.log("returnValue:true");
+                event.returnValue = true;
+            })["catch"](function () {
+                // 失敗時の処理
+                console.log("returnValue:false");
+                event.returnValue = false;
+            })];
+    });
+}); });
+// URLを外部ブラウザーで開く
+handle(ipc_id_1.IpcId.OPEN_EXTERNAL_BROWSER, function (event, pageUrl) { return __awaiter(void 0, void 0, void 0, function () {
+    return __generator(this, function (_a) {
+        switch (_a.label) {
+            case 0: return [4 /*yield*/, electron_1.shell.openExternal(pageUrl)];
+            case 1:
+                _a.sent();
+                return [2 /*return*/];
+        }
+    });
+}); });

--- a/product/dist-config/preload.js
+++ b/product/dist-config/preload.js
@@ -9,6 +9,14 @@ contextBridge.exposeInMainWorld('api', {
   on: (channel, listener) => {
     return ipcRenderer.on(channel, listener);
   },
+  /**
+   * @param {string} channel 
+   * @param  {...any} args 
+   * @returns Promise
+   */
+  invoke: (channel, ...args) => {
+    return ipcRenderer.invoke(channel, ...args);
+  },
   path: {
     extname: value => {
       return require('path').extname(value);

--- a/product/src/app/components/app/app.html
+++ b/product/src/app/components/app/app.html
@@ -13,10 +13,16 @@
           #optionSelecter
           (change)="handlePresetChange(optionSelecter.value)"
         >
-          <option [value]="PresetType.LINE" [selected]="presetMode === PresetType.LINE">
+          <option
+            [value]="PresetType.LINE"
+            [selected]="presetMode === PresetType.LINE"
+          >
             {{ localeData.PROP_useItemLine }}
           </option>
-          <option [value]="PresetType.WEB" [selected]="presetMode === PresetType.WEB">
+          <option
+            [value]="PresetType.WEB"
+            [selected]="presetMode === PresetType.WEB"
+          >
             {{ localeData.PROP_useItemWeb }}
           </option>
         </select>
@@ -46,7 +52,7 @@
     <app-anim-preview
       [animationOptionData]="animationOptionData"
       [items]="items"
-      [openingDirectories]="openingDirectories"
+      [openingDirectories]="isUiLocked"
       (clickFileSelectButtonEvent)="handleClickFileSelectButton()"
     >
     </app-anim-preview>

--- a/product/src/app/process/ipc.service.ts
+++ b/product/src/app/process/ipc.service.ts
@@ -1,10 +1,8 @@
 import { Injectable } from '@angular/core';
-import { IpcId } from '../../../common-src/ipc-id';
+import { IpcId, IpcInvoke } from '../../../common-src/ipc-id';
 import { AnimationImageOptions } from '../../../common-src/data/animation-image-option';
 import { ImageData } from '../../../common-src/data/image-data';
 import { ILocaleData } from '../../../common-src/i18n/locale-data.interface';
-import { IpcRenderer } from 'electron';
-import { ServiceEvent } from './ServiceEvent';
 
 interface Path {
   extname: (path: string) => string;
@@ -13,62 +11,28 @@ interface Path {
 }
 
 interface Api {
-  send: (channel: string, ...values: any) => any;
-  sendSync: (channel: string, ...values: any) => any;
-  on: (
-    channel: string,
-    listener: (event: any, value: any) => void
-  ) => IpcRenderer;
   path: Path;
+  invoke: IpcInvoke;
 }
 
 @Injectable()
 export default class IpcService {
   private api: Api;
   public path: Path;
-  private readonly events = {
-    /** 画像選択完了時のイベント */
-    selectedOpenImages: new ServiceEvent<string[]>(),
-    /** UIロック解除要求のイベント */
-    unlockSelectUi: new ServiceEvent<void>()
-  };
 
   constructor() {
     this.api = (window as any).api;
     this.path = this.api.path;
-
-    // メインプロセスから画像選択ダイアログのクローズ（「開く」選択）を受信した時
-    this.api.on(
-      IpcId.SELECTED_OPEN_IMAGES,
-      (event: any, value: { canceled: boolean; filePaths: string[] }) => {
-        this.events.selectedOpenImages.fire(value.filePaths);
-      }
-    );
-
-    // メインプロセスからUIロックの解除要求を受信した時
-    this.api.on(IpcId.UNLOCK_SELECT_UI, () => {
-      this.events.unlockSelectUi.fire();
-    });
-  }
-
-  /** 画像選択ダイアログで画像が選択された時のイベントハンドラーを登録します */
-  onSelectedOpenImages(handler: (list: string[]) => void) {
-    this.events.selectedOpenImages.add(handler);
-  }
-
-  /** メインプロセスからUIロックの解除を要求された時のイベントハンドラーを登録します */
-  onUnlockSelectUi(handler: () => void) {
-    this.events.unlockSelectUi.add(handler);
   }
 
   /** UIからメインプロセス側にアプリの動作設定を共有します */
   sendConfigData(localeData: ILocaleData) {
-    this.api.send(IpcId.SET_CONFIG_DATA, localeData);
+    return this.api.invoke(IpcId.SET_CONFIG_DATA, localeData);
   }
 
   /** 画像選択ダイアログを開きます。結果を受け取るにはonSelectedOpenImagesにイベントハンドラーを登録します */
   openFileDialog() {
-    this.api.send(IpcId.OPEN_FILE_DIALOG);
+    return this.api.invoke(IpcId.OPEN_FILE_DIALOG);
   }
 
   /** エラーを送信します */
@@ -79,12 +43,19 @@ export default class IpcService {
     title: string,
     detail: string
   ) {
-    this.api.sendSync(IpcId.SEND_ERROR, version, code, category, title, detail);
+    return this.api.invoke(
+      IpcId.SEND_ERROR,
+      version,
+      code,
+      category,
+      title,
+      detail
+    );
   }
 
   /** 指定のURLを外部ブラウザで開きます */
   openExternalBrowser(url: string) {
-    this.api.sendSync(IpcId.OPEN_EXTERNAL_BROWSER, url);
+    return this.api.invoke(IpcId.OPEN_EXTERNAL_BROWSER, url);
   }
 
   /** 画像の変換・保存処理を実行します */
@@ -92,20 +63,12 @@ export default class IpcService {
     version: string,
     itemList: ImageData[],
     animationOptionData: AnimationImageOptions
-  ): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const result = this.api.sendSync(
-        IpcId.EXEC_IMAGE_EXPORT_PROCESS,
-        version,
-        itemList,
-        animationOptionData
-      );
-      console.log(`exec finished: result=${result}`);
-      if (result) {
-        resolve();
-      } else {
-        reject();
-      }
-    });
+  ) {
+    return this.api.invoke(
+      IpcId.EXEC_IMAGE_EXPORT_PROCESS,
+      version,
+      itemList,
+      animationOptionData
+    );
   }
 }


### PR DESCRIPTION
#24 
保存等のメインプロセス側の処理を非同期で呼び出すように変更しました。
これまで保存中は固まったように見えてしまっていましたが、現行(2.1.8)と同様にローディングが表示されるようになります。

■ 修正概要
- プロセス間の通信を`send/on`から`invoke/handle`に変更し、Promiseを返せるようにしました
- プロセス間の通信の引数/戻り値に型をつけました
- 不要になった定数及び処理（メイン側からの戻りに使用していたもの）を削除しました