### PR TITLE
Fix/35 windows alert title

### DIFF
--- a/product/build-scripts/for-windows-packaging.js
+++ b/product/build-scripts/for-windows-packaging.js
@@ -11,7 +11,6 @@ electronPackager({
   electronVersion: conf.ELECTRON_VERSION,
   overwrite: true,
   asar: false,
-  appBundleId: conf.sign.bundleId,
   appVersion: conf.APP_VERSION,
   buildVersion: conf.BUILD_VERSION,
   appCopyright: conf.COPY_RIGHT,

--- a/product/build-scripts/for-windows-store-packaging.js
+++ b/product/build-scripts/for-windows-store-packaging.js
@@ -35,7 +35,6 @@ electronPackager({
   electronVersion: conf.ELECTRON_VERSION,
   overwrite: true,
   asar: false,
-  appBundleId: conf.sign.bundleId,
   appVersion: conf.APP_VERSION,
   appCopyright: 'Copyright (C) 2018 ICS INC.'
 })

--- a/product/common-src/config/app-config.ts
+++ b/product/common-src/config/app-config.ts
@@ -5,5 +5,7 @@ export const AppConfig = {
   /** アプリケーションのバージョン番号を示します。 */
   version: '2.1.8',
   /** アナリティクス用のバージョン表記です。 */
-  analyticsVersion: '2.1.8'
+  analyticsVersion: '2.1.8',
+  /** （ローカライズされていない）アプリケーション名です */
+  appName: 'Animation Image Converter'
 } as const;

--- a/product/common-src/ipc-id.ts
+++ b/product/common-src/ipc-id.ts
@@ -11,7 +11,8 @@ export const IpcId = {
   SET_CONFIG_DATA: 'set-config-data',
   SEND_ERROR: 'send-error',
   EXEC_IMAGE_EXPORT_PROCESS: 'exec-image-export-process',
-  OPEN_EXTERNAL_BROWSER: 'open-external-browser'
+  OPEN_EXTERNAL_BROWSER: 'open-external-browser',
+  SHOW_MESSAGE: 'show-message'
 } as const;
 
 // UI→メイン方向にinvokeで起動する処理の型定義
@@ -33,6 +34,7 @@ interface IpcInvokeFuncs {
     animationOptionData: AnimationImageOptions
   ) => Promise<void>;
   [IpcId.OPEN_EXTERNAL_BROWSER]: (url: string) => Promise<void>;
+  [IpcId.SHOW_MESSAGE]: (message: string, title?: string) => Promise<void>;
 }
 
 // IpcRenderer.invokeの型定義

--- a/product/main-src/main.ts
+++ b/product/main-src/main.ts
@@ -17,6 +17,7 @@ import { ILocaleData } from '../common-src/i18n/locale-data.interface';
 import { ApplicationMenu } from './menu/application-menu';
 import { SaveDialog } from './dialog/SaveDialog';
 import { sendError } from './error/send-error';
+import { AppConfig } from '../common-src/config/app-config';
 
 // アプリケーション作成用のモジュールを読み込み
 const errorMessage = new ErrorMessage();
@@ -197,7 +198,9 @@ handle(IpcId.OPEN_EXTERNAL_BROWSER, async (event, pageUrl: string) => {
 //   代替としてメインプロセス側でelectronのdialogを使用してメッセージを表示する機能を提供する
 handle(IpcId.SHOW_MESSAGE, async (event, message: string, title?: string) => {
   await dialog.showMessageBox({
-    message,
-    title
-  })
+    type: 'info',
+    buttons: ['OK'],
+    title: title ?? AppConfig.appName,
+    message: message
+})
 })

--- a/product/main-src/main.ts
+++ b/product/main-src/main.ts
@@ -191,3 +191,13 @@ handle(
 handle(IpcId.OPEN_EXTERNAL_BROWSER, async (event, pageUrl: string) => {
   await shell.openExternal(pageUrl);
 });
+
+// メッセージを表示する
+// ※ レンダラー側でalertを使用するとビルド語のWindows環境で文字化けが発生するため、
+//   代替としてメインプロセス側でelectronのdialogを使用してメッセージを表示する機能を提供する
+handle(IpcId.SHOW_MESSAGE, async (event, message: string, title?: string) => {
+  await dialog.showMessageBox({
+    message,
+    title
+  })
+})

--- a/product/src/app/components/app/app.ts
+++ b/product/src/app/components/app/app.ts
@@ -129,7 +129,7 @@ export class AppComponent implements OnInit, AfterViewInit {
     }
   }
 
-  generateAnimImage() {
+  async generateAnimImage(): Promise<void> {
     // 	画像が選択されていないので保存しない。
     if (!this.isImageSelected) {
       return;
@@ -140,23 +140,23 @@ export class AppComponent implements OnInit, AfterViewInit {
       this.animationOptionData.enabledExportWebp === false
     ) {
       // TODO: 多言語対応
-      alert('出力画像の形式を選択ください。');
+      await this.ipcService.showMessage('出力画像の形式を選択ください。');
       return;
     }
 
-    this._exportImages();
+    await this._exportImages();
   }
 
-  showFileSizeErrorMessage(): void {
+  async showFileSizeErrorMessage(): Promise<void> {
     // TODO: 多言語対応
-    alert(
+    await this.ipcService.showMessage(
       '連番画像のサイズが異なるため、APNGファイルの保存ができません。連番画像のサイズが統一されているか確認ください。'
     );
   }
 
-  async _exportImages() {
+  async _exportImages(): Promise<void> {
     if (this.apngFileSizeError && this.animationOptionData.enabledExportApng) {
-      this.showFileSizeErrorMessage();
+      await this.showFileSizeErrorMessage();
       return;
     }
 
@@ -201,7 +201,7 @@ export class AppComponent implements OnInit, AfterViewInit {
   /**
    * ファイル選択ボタンが押された時のハンドラーです。
    */
-  async handleClickFileSelectButton() {
+  async handleClickFileSelectButton(): Promise<void> {
     this.showLockDialog();
     try {
       const files = await this.ipcService.openFileDialog();
@@ -218,7 +218,7 @@ export class AppComponent implements OnInit, AfterViewInit {
    *
    * @param filePathList
    */
-  setFilePathList(filePathList: string[]): void {
+  async setFilePathList(filePathList: string[]): Promise<void> {
     const path = this.ipcService.path;
     const isPngFile = (name: string) => path.extname(name) === '.png';
     // 	再度アイテムがドロップされたらリセットするように調整
@@ -230,7 +230,7 @@ export class AppComponent implements OnInit, AfterViewInit {
           0 // changeImageItemsでセットする際にソートされるので、一旦0で登録
         )
     );
-    this.changeImageItems(items);
+    await this.changeImageItems(items);
   }
 
   /**
@@ -252,11 +252,11 @@ export class AppComponent implements OnInit, AfterViewInit {
     });
   }
 
-  changeImageItems(items: ImageData[]): void {
+  async changeImageItems(items: ImageData[]): Promise<void> {
     this.items = items;
     this.numbering();
     if (items.length >= 1) {
-      this.checkImageSize(items);
+      await this.checkImageSize(items);
       this.animationOptionData.imageInfo.length = items.length;
     }
     this.isImageSelected = this.items.length >= 1;
@@ -280,7 +280,7 @@ export class AppComponent implements OnInit, AfterViewInit {
       // 不一致ならエラーフラグを立てた上でエラーメッセージを表示
       this.apngFileSizeError = true;
       const msg = `${errorItem.imageBaseName} ${this.localeData.VALIDATE_ImportImageSize}`;
-      alert(msg);
+      await this.ipcService.showMessage(msg);
     }
   }
 }

--- a/product/src/app/i18n/locale-en.ts
+++ b/product/src/app/i18n/locale-en.ts
@@ -1,7 +1,8 @@
+import { AppConfig } from '../../../common-src/config/app-config';
 import { LocaleData } from './locale-data';
 
 export class LocaleEnData extends LocaleData {
-  APP_NAME = 'Animation Image Converter';
+  APP_NAME = AppConfig.appName;
 
   PROP_use = 'Type';
   PROP_useItemLine = 'LINE Animation Stamp';

--- a/product/src/app/process/ipc.service.ts
+++ b/product/src/app/process/ipc.service.ts
@@ -71,4 +71,9 @@ export default class IpcService {
       animationOptionData
     );
   }
+
+  /** メッセージダイアログを表示します。alert()の代替として使用します */
+  showMessage(message: string, title?: string) {
+    return this.api.invoke(IpcId.SHOW_MESSAGE, message, title)
+  }
 }


### PR DESCRIPTION
#35 の対応を行いました

■ 事象と原因
- Windows環境ではalertダイアログのタイトルに自動的にアプリ名が設定されるが、ビルド後のアプリ名が日本語の場合、文字化けする
- メインプロセス側で`electron.dialog.messageBox`を使用しても同じ問題が発生する。ただしこちらは`alert()`と異なりタイトルを明示的に設定できるため回避可能

■ 対処
- alertをメインプロセス側の`electron.dialog.messageBox`に置き換える
- タイトルを明示しない場合はアプリ名（英字表記）を使用する

![image](https://user-images.githubusercontent.com/59550270/153985639-258fa758-573d-40e6-a56b-88e297299739.png)
![image](https://user-images.githubusercontent.com/59550270/153985658-c25a7635-2ad4-47fb-af6e-43ec74cc6ae5.png)
![image](https://user-images.githubusercontent.com/59550270/153985683-dd6dc804-cf2b-4a90-b0be-8a8ef1e9aee7.png)
