### PR TITLE
起動時に稀に空白のウインドウが表示されてハングする問題の修正

### DIFF
--- a/product/main-src/main.ts
+++ b/product/main-src/main.ts
@@ -90,10 +90,8 @@ app.on('window-all-closed', () => {
 // アプリケーションがアクティブになった時の処理(Macだと、Dockがクリックされた時）
 app.on('activate', () => {
   /// メインウィンドウが消えている場合は再度メインウィンドウを作成する
-  console.log('active-with-open-window', mainWindow);
-  if (mainWindow === undefined) {
-    createWindow();
-  } else {
+  console.log('activate-window', mainWindow);
+  if (mainWindow) {
     mainWindow.show();
   }
 });


### PR DESCRIPTION
内部の動作検証で発生していた「特定の端末で10回に1回程度、起動時に空白のウインドウが表示されたまま固まる」事象の修正を行いました。

■ 原因
- 起動時に初期化が完了(`ready`)する前にウインドウの生成処理が呼び出されている
- なぜ特定環境のみで発生していたのかは不明です

■ 対処
- ウインドウの生成処理は初期化完了時`ready`とアプリケーションがアクティブになった時`activate`でしか行っていないため、後者の処理を削除しました
- 元々このアプリではウインドウは1枚しか出さず、かつ全てのウインドウを閉じるとアプリ自体を終了する仕様のため、「アクティブになった時にウインドウがなければ再生成する」という既存の処理に実質的な意味はなく、削除することによる問題は生じないと考えています