### PR TITLE
アナリティクスが記録されない問題を修正

### DIFF
--- a/product/common-src/config/app-config.ts
+++ b/product/common-src/config/app-config.ts
@@ -1,11 +1,12 @@
+const version = '3.0'
 /**
  * アプリケーションの情報を提供します。
  */
 export const AppConfig = {
   /** アプリケーションのバージョン番号を示します。 */
-  version: '3.0',
+  version: version,
   /** アナリティクス用のバージョン表記です。 */
-  analyticsVersion: '3.0',
+  analyticsUrl: `https://ics-web.jp/projects/animation-image-tool/?v=${version}`,
   /** （ローカライズされていない）アプリケーション名です */
   appName: 'Animation Image Converter'
 } as const;

--- a/product/main-src/main.ts
+++ b/product/main-src/main.ts
@@ -40,6 +40,7 @@ const createWindow = () => {
       nodeIntegration: false,
       contextIsolation: true,
       backgroundThrottling: false,
+      webviewTag: true,
       preload: path.join(__dirname, '../preload.js')
     }
   });

--- a/product/src/app/components/app/app.html
+++ b/product/src/app/components/app/app.html
@@ -100,4 +100,4 @@
 </dialog>
 
 <!-- Google Analytics -->
-<iframe class="tracking-ga" [src]="gaUrl" width="1" height="1"> </iframe>
+<webview class="tracking-ga" [src]="gaUrl" width="1" height="1"></webview>

--- a/product/src/app/components/app/app.html
+++ b/product/src/app/components/app/app.html
@@ -98,6 +98,3 @@
 <dialog style="display: none">
   <img src="assets/imgs/preloader.webp" width="52" height="52" />
 </dialog>
-
-<!-- Google Analytics -->
-<webview class="tracking-ga" [src]="gaUrl" width="1" height="1"></webview>

--- a/product/src/app/components/app/app.ts
+++ b/product/src/app/components/app/app.ts
@@ -44,7 +44,6 @@ export class AppComponent implements OnInit, AfterViewInit {
   _isDragover = false;
   presetMode = PresetType.LINE;
   items: ImageData[] = [];
-  readonly gaUrl = AppConfig.analyticsUrl;
   PresetType = PresetType;
 
   @Input()

--- a/product/src/app/components/app/app.ts
+++ b/product/src/app/components/app/app.ts
@@ -9,7 +9,7 @@ import {
 import { AppConfig } from '../../../../common-src/config/app-config';
 import { LocaleData } from '../../i18n/locale-data';
 import { LocaleManager } from '../../i18n/locale-manager';
-import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { DomSanitizer } from '@angular/platform-browser';
 import IpcService from '../../process/ipc.service';
 import { PresetType } from '../../../../common-src/type/PresetType';
 import { PresetLine } from '../../../../common-src/preset/preset-line';
@@ -44,7 +44,7 @@ export class AppComponent implements OnInit, AfterViewInit {
   _isDragover = false;
   presetMode = PresetType.LINE;
   items: ImageData[] = [];
-  gaUrl: SafeResourceUrl;
+  readonly gaUrl = AppConfig.analyticsUrl;
   PresetType = PresetType;
 
   @Input()
@@ -61,10 +61,6 @@ export class AppComponent implements OnInit, AfterViewInit {
     sanitizer: DomSanitizer,
     private ipcService: IpcService
   ) {
-    this.gaUrl = sanitizer.bypassSecurityTrustResourceUrl(
-      'http://ics-web.jp/projects/animation-image-tool/?v=' +
-        AppConfig.analyticsVersion
-    );
     new LocaleManager().applyClientLocale(localeData);
   }
 

--- a/product/src/main.ts
+++ b/product/src/main.ts
@@ -1,5 +1,6 @@
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppConfig } from '../common-src/config/app-config';
 
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
@@ -8,6 +9,21 @@ if (environment.production) {
   enableProdMode();
 }
 
+/**
+ * Google Analyticsの初期化
+ * GAを読み込むためのwebview（electronが提供するカスタムエレメント）を生成し、body直下に追加します
+ */
+const loadAnalytics = () => {
+  const url = AppConfig.analyticsUrl;
+  const webview = document.createElement('webview');
+  webview.className = 'tracking-ga';
+  webview.setAttribute('src', url);
+  webview.setAttribute('width', '1');
+  webview.setAttribute('height', '1');
+  document.body.appendChild(webview);
+};
+
 window.addEventListener('DOMContentLoaded', () => {
   platformBrowserDynamic().bootstrapModule(AppModule);
+  loadAnalytics();
 });


### PR DESCRIPTION
Electronのバージョンを上げたことでGAのログが飛ばなくなっていた件の修正です。

■ 変更概要
- GA記録のためにICSのwebページを読み込む先をiframeからElectronのwebviewに変更しました
- httpからhttpsに変更しました

以前の方法と完全に同一かは確認できていませんが、ひとまずGAのリアルタイムビューで新しいv3.0のログが飛んできていることは確認できたので、記録自体は問題ないかと思います。