### PR TITLE
拡張子の大文字も対応

### DIFF
--- a/product/src/app/components/app/app.ts
+++ b/product/src/app/components/app/app.ts
@@ -220,7 +220,7 @@ export class AppComponent implements OnInit, AfterViewInit {
    */
   async setFilePathList(filePathList: string[]): Promise<void> {
     const path = this.ipcService.path;
-    const isPngFile = (name: string) => /.png/i.test(path.extname(name));
+    const isPngFile = (name: string) => path.extname(name).toLowerCase() === '.png';
     // 	再度アイテムがドロップされたらリセットするように調整
     const items = filePathList.filter(isPngFile).map(
       (filePath) =>

--- a/product/src/app/components/app/app.ts
+++ b/product/src/app/components/app/app.ts
@@ -220,7 +220,7 @@ export class AppComponent implements OnInit, AfterViewInit {
    */
   async setFilePathList(filePathList: string[]): Promise<void> {
     const path = this.ipcService.path;
-    const isPngFile = (name: string) => path.extname(name) === '.png';
+    const isPngFile = (name: string) => /.png/i.test(path.extname(name));
     // 	再度アイテムがドロップされたらリセットするように調整
     const items = filePathList.filter(isPngFile).map(
       (filePath) =>


### PR DESCRIPTION
`.PNG`という大文字拡張子の場合に追加されない不具合を修正しました。判定ロジックを正規表現に変更しています。（.pNgのようなのも拾うようになっています）

ご確認お願いします。