### PR TITLE
electron部分のApple Silicon対応

### DIFF
--- a/product/build-scripts/.eslintrc.json
+++ b/product/build-scripts/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "rules": {
+    "no-undef": "error"
+  },
+  "env": {
+    "es6": true,
+    "node": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2020
+  }
+}

--- a/product/build-scripts/for-mac-packaging.js
+++ b/product/build-scripts/for-mac-packaging.js
@@ -137,8 +137,8 @@ const buildUniversal = async () => {
 
   // 再度binをコピー
   cpx.copySync(
-    `conf.packageTmpPath.darwin/bin`,
-    `${appPathUniversal}/Contents/Resources/app/`
+    `${conf.packageTmpPath.darwin}/bin/*`,
+    `${appPathUniversal}/Contents/Resources/app/bin/`
   );
 
   // x64, armの各ビルドを削除

--- a/product/build-scripts/for-mac-packaging.js
+++ b/product/build-scripts/for-mac-packaging.js
@@ -1,93 +1,163 @@
 const process = require('process');
+const fs = require('fs');
+const cpx = require('cpx');
+const del = require('del');
+const { join, resolve } = require('path');
+const electronPackager = require('electron-packager');
+const { makeUniversalApp } = require('@electron/universal');
+
 const conf = require('./conf.js');
-
-const appDirectory = `${conf.JP_NAME}-mas-x64`;
-const appPath = `${appDirectory}/${conf.JP_NAME}.app`;
-
 // 開発バージョン:development , リリースバージョン:distribution
 const signType = process.argv[3];
 
-const signConfigStr = require('fs').readFileSync(`../../cert/${signType}.json`, 'utf-8');
-const signConfig = JSON.parse(signConfigStr);
+const appDirectoryX64 = `${conf.JP_NAME}-mas-x64`;
+const appDirectoryArm = `${conf.JP_NAME}-mas-arm64`;
+const appDirectoryUniversal = `${conf.JP_NAME}-mas-universal`;
+const appPathX64 = `${appDirectoryX64}/${conf.JP_NAME}.app`;
+const appPathArm = `${appDirectoryArm}/${conf.JP_NAME}.app`;
+const appPathUniversal = `${appDirectoryUniversal}/${conf.JP_NAME}.app`;
+const certConfigPath = `../../cert/${signType}.json`;
 
-function startFlat() {
+const loadCertConfig = () => {
+  if (!fs.existsSync(certConfigPath)) return undefined;
+  const signConfigStr = fs.readFileSync(certConfigPath, 'utf-8');
+  return JSON.parse(signConfigStr);
+};
+
+const signConfig = loadCertConfig();
+
+const execFlat = () => {
   console.log('start flat...');
+  if (!signConfig) {
+    console.error('No cert config. aborted.');
+    return;
+  }
   const flat = require('electron-osx-sign').flat;
   const pkg = `AnimationImageConverter_${signType}.pkg`;
 
-  flat(
-    {
-      app: appPath,
-      identity: signConfig.flat.identity,
-      pkg: `../${pkg}`,
-      platform: 'mas'
-    },
-    function done(err) {
-      if (err) {
-        console.error(err);
-        console.error('flat failure!');
-        return;
+  return new Promise((resolve, reject) => {
+    flat(
+      {
+        app: appPathUniversal,
+        identity: signConfig.flat.identity,
+        pkg: `../${pkg}`,
+        platform: 'mas'
+      },
+      (err) => {
+        if (err) {
+          console.error(err);
+          console.error('flat failure!');
+          reject();
+        } else {
+          console.info('flat done!');
+          resolve();
+        }
       }
-      console.info('flat done!');
-    }
-  );
-}
+    );
+  });
+};
 
-function startSign() {
+const execSign = () => {
   console.log('start sign...');
+  if (!signConfig) {
+    console.error('No cert config. aborted.');
+    return;
+  }
   const sign = require('electron-osx-sign');
 
-  sign(
-    {
-      'app': appPath,
-      'entitlements': 'resources/dev/parent.plist',
-      'entitlements-inherit': 'resources/dev/child.plist',
-      'platform': 'mas',
-      'provisioning-profile': `../../cert/${signType}.provisionprofile`,
-      'type': signType,
-      'identity': signConfig.sign.identity
-    },
-    function (err) {
-      if (err) {
-        console.error(err);
-        console.error('sign failure!');
-
-        return;
-      }
-      if (signConfig.flat.enabled)
+  return new Promise((resolve, reject) => {
+    sign(
       {
-        startFlat();
+        app: appPathUniversal,
+        entitlements: 'resources/dev/parent.plist',
+        'entitlements-inherit': 'resources/dev/child.plist',
+        platform: 'mas',
+        'provisioning-profile': `../../cert/${signType}.provisionprofile`,
+        type: signType,
+        identity: signConfig.sign.identity
+      },
+      (err) => {
+        if (err) {
+          console.error(err);
+          console.error('sign failure!');
+          reject();
+        } else {
+          console.info('sign done!');
+          resolve();
+        }
       }
-    }
-  );
-}
-
-// パッケージング前にフォルダを削除
-require('del').sync([`${appDirectory}/**`]);
-
-const electronPackager = require('electron-packager');
-electronPackager({
-  name: conf.JP_NAME,
-  dir: conf.packageTmpPath.darwin,
-  out: './',
-  icon: './resources/app.icons',
-  platform: 'mas',
-  arch: 'x64',
-  electronVersion: conf.ELECTRON_VERSION,
-  overwrite: true,
-  asar: false,
-  extendInfo: './resources/dev/info.plist',
-  appBundleId: signConfig.bundleId,
-  appVersion: conf.APP_VERSION,
-  buildVersion: conf.BUILD_VERSION,
-  appCopyright: conf.COPY_RIGHT
-})
-  .then((appPaths) => {
-    console.info('[electron-packager] success : ' + appPaths);
-    // コードサイニング証明書を付与
-    startSign();
-  })
-  .catch((err) => {
-    // エラーが発生したのでログを表示して終了
-    console.error('[electron-packager] failure : ' + err);
+    );
   });
+};
+
+const buildUniversal = async () => {
+  // バッケージビルド設定（アーキテクチャ共通）
+  const settings = {
+    name: conf.JP_NAME,
+    dir: conf.packageTmpPath.darwin,
+    out: './',
+    icon: './resources/app.icons',
+    platform: 'mas',
+    electronVersion: conf.ELECTRON_VERSION,
+    overwrite: true,
+    asar: false,
+    extendInfo: './resources/dev/info.plist',
+    appBundleId: signConfig?.bundleId,
+    appVersion: conf.APP_VERSION,
+    buildVersion: conf.BUILD_VERSION,
+    appCopyright: conf.COPY_RIGHT
+  };
+
+  // x64, armそれぞれをビルド
+  await electronPackager({ ...settings, arch: 'x64' });
+  await electronPackager({ ...settings, arch: 'arm64' });
+
+  // 一度binを削除
+  // binのモジュールにはユニバーサル対応されていないものが含まれているため@electron/universalに渡せない
+  // 一旦削除して、ユニバーサル化した後で再度コピーする（bin部分はarmマシンでもx64のRosseta2経由で動く）
+  del.sync([`${appPathX64}/Contents/Resources/app/bin`]);
+  del.sync([`${appPathArm}/Contents/Resources/app/bin`]);
+
+  // ユニバーサルアプリの保存先フォルダを作成
+  fs.mkdirSync(appDirectoryUniversal);
+  // アプリ本体以外のファイルをコピー
+  ['version', 'LICENSE', 'LICENSES.chromium.html'].map((name) =>
+    fs.copyFileSync(
+      join(appDirectoryX64, name),
+      join(appDirectoryUniversal, name)
+    )
+  );
+
+  // ユニバーサル化
+  await makeUniversalApp({
+    x64AppPath: resolve(appPathX64),
+    arm64AppPath: resolve(appPathArm),
+    outAppPath: resolve(appPathUniversal)
+  });
+
+  // 再度binをコピー
+  cpx.copySync(
+    `conf.packageTmpPath.darwin/bin`,
+    `${appPathUniversal}/Contents/Resources/app/`
+  );
+
+  // x64, armの各ビルドを削除
+  del.sync([`${appDirectoryX64}/**`]);
+  del.sync([`${appDirectoryArm}/**`]);
+
+  return appPathUniversal;
+};
+
+const main = async () => {
+  // パッケージング前にフォルダを削除
+  del.sync([`${appDirectoryX64}/**`]);
+  del.sync([`${appDirectoryArm}/**`]);
+  del.sync([`${appDirectoryUniversal}/**`]);
+
+  const app = await buildUniversal();
+  console.info('[electron-packager] success : ' + app);
+  await execSign();
+  await execFlat();
+};
+
+main();

--- a/product/package.json
+++ b/product/package.json
@@ -51,6 +51,7 @@
     "@angular/cli": "13.2.0",
     "@angular/compiler-cli": "13.2.0",
     "@angular/language-service": "13.2.0",
+    "@electron/universal": "^1.2.1",
     "@types/jquery": "^3.5.6",
     "@types/node": "^16.4.14",
     "@typescript-eslint/eslint-plugin": "5.10.1",


### PR DESCRIPTION
#21 の対応としてアプリ本体（electron部分）のApple Silicon対応（ユニバーサル化）を行いました。
x86-64とarm64でそれぞれパッケージを作った後、@electron/universalで結合しています。

binディレクトリの画像変換モジュールはapngasmのApple Silicon対応バイナリが入手できないためユニバーサル化の対象外としています。
このため、アプリ本体の起動は高速になりますが、画像変換自体のパフォーマンスは変わりません。

■ 確認いただきたい点
- 私の環境ではコードサイン周りを確認できていないので、sign&flat等のリリースに向けた既存の処理に影響を及ぼしていないか、確認いただけるとありがたいです