### PR TITLE
生成されるhtmlの内容を新しくする

### DIFF
--- a/product/common-src/i18n/locale-data.interface.ts
+++ b/product/common-src/i18n/locale-data.interface.ts
@@ -63,6 +63,14 @@ export interface ILocaleData {
   MENU_helpOnline: string;
   MENU_helpQuestion: string;
 
+  HTML_lang: string;
+  HTML_availableFirefoxSafariChrome: string;
+  HTML_cantAnimateOnIE: string;
+  HTML_cantViewOnIE: string;
+  HTML_forWebpSupportedBrowsers: string;
+  HTML_forWebpUnsupportedBrowsers: string;
+  HTML_backgroundCssComment: string;
+
   VALIDATE_ImportImageSize: string;
   VALIDATE_title: string;
 

--- a/product/common-src/i18n/localeDataEn.ts
+++ b/product/common-src/i18n/localeDataEn.ts
@@ -59,6 +59,14 @@ export const localeDataEn: ILocaleData = {
   MENU_helpOnline: 'Online Help',
   MENU_helpQuestion: 'Report Issues',
 
+  HTML_lang: 'en',
+  HTML_availableFirefoxSafariChrome: 'Animation available on Firefox, Safari and Chrome',
+  HTML_cantAnimateOnIE: 'IE does not support to play the animation',
+  HTML_cantViewOnIE: 'IE does not support to display the image',
+  HTML_forWebpSupportedBrowsers: 'for webp supported browsers',
+  HTML_forWebpUnsupportedBrowsers: 'for webp unsupported browsers',
+  HTML_backgroundCssComment: 'Paint checkerboard pattern for preview background using CSS',
+
   VALIDATE_ImportImageSize: `'s width and height is different from other image.`,
   VALIDATE_title: 'Warning for LINE Stamp',
 

--- a/product/common-src/i18n/localeDataEn.ts
+++ b/product/common-src/i18n/localeDataEn.ts
@@ -31,9 +31,9 @@ export const localeDataEn: ILocaleData = {
   PROP_tabQualityHWebp: 'Export as WebP',
   PROP_tabQualityHHtml: 'Export as HTML',
 
-  PROP_tabQualityHApngTooltip: '',
-  PROP_tabQualityHWebpTooltip: '',
-  PROP_tabQualityHHtmlTooltip: '',
+  PROP_tabQualityHApngTooltip: 'APNG is an animated image format that supported by most of major browsers.',
+  PROP_tabQualityHWebpTooltip: 'WebP is a newer format for animated image. Some old browsers don\'t support to display or play.',
+  PROP_tabQualityHHtmlTooltip: 'generate html file for preview output images.',
 
   PROP_btnSave: 'Export',
 

--- a/product/common-src/i18n/localeDataEn.ts
+++ b/product/common-src/i18n/localeDataEn.ts
@@ -63,8 +63,8 @@ export const localeDataEn: ILocaleData = {
   HTML_availableFirefoxSafariChrome: 'Animation available on Firefox, Safari and Chrome',
   HTML_cantAnimateOnIE: 'IE does not support to play the animation',
   HTML_cantViewOnIE: 'IE does not support to display the image',
-  HTML_forWebpSupportedBrowsers: 'for webp supported browsers',
-  HTML_forWebpUnsupportedBrowsers: 'for webp unsupported browsers',
+  HTML_forWebpSupportedBrowsers: 'for WebP supported browsers',
+  HTML_forWebpUnsupportedBrowsers: 'for WebP unsupported browsers',
   HTML_backgroundCssComment: 'Paint checkerboard pattern for preview background using CSS',
 
   VALIDATE_ImportImageSize: `'s width and height is different from other image.`,

--- a/product/common-src/i18n/localeDataJa.ts
+++ b/product/common-src/i18n/localeDataJa.ts
@@ -65,8 +65,8 @@ export const localeDataJa: ILocaleData = {
   HTML_availableFirefoxSafariChrome: 'Firefox, Safari, Chromeで再生可能',
   HTML_cantAnimateOnIE: 'IEではアニメは再生できません',
   HTML_cantViewOnIE: 'IEでは表示できません',
-  HTML_forWebpSupportedBrowsers: 'webp対応ブラウザ用',
-  HTML_forWebpUnsupportedBrowsers: 'webp非対応ブラウザ用',
+  HTML_forWebpSupportedBrowsers: 'WebP対応ブラウザ用',
+  HTML_forWebpUnsupportedBrowsers: 'WebP非対応ブラウザ用',
   HTML_backgroundCssComment: 'プレビュー背景のチェック模様をCSSで表示する',
 
   VALIDATE_ImportImageSize:

--- a/product/common-src/i18n/localeDataJa.ts
+++ b/product/common-src/i18n/localeDataJa.ts
@@ -33,8 +33,8 @@ export const localeDataJa: ILocaleData = {
   PROP_tabQualityHWebp: 'WebPファイル出力',
   PROP_tabQualityHHtml: 'HTMLファイル出力',
 
-  PROP_tabQualityHApngTooltip: 'APNGはFirefoxやSafari用のアニメ画像形式です',
-  PROP_tabQualityHWebpTooltip: 'WebPはChromeブラウザ用のアニメ画像形式です',
+  PROP_tabQualityHApngTooltip: 'APNGはほとんどの主要ブラウザーで利用できるアニメ画像形式です',
+  PROP_tabQualityHWebpTooltip: 'WebPはAPNGよりも新しいアニメ画像形式です。古いブラウザー等では表示や再生ができないことがあります',
   PROP_tabQualityHHtmlTooltip: 'アニメ画像を表示するためのHTMLを作成します',
 
   PROP_btnSave: 'アニメ画像を保存する',

--- a/product/common-src/i18n/localeDataJa.ts
+++ b/product/common-src/i18n/localeDataJa.ts
@@ -61,6 +61,14 @@ export const localeDataJa: ILocaleData = {
   MENU_helpOnline: 'オンラインヘルプ',
   MENU_helpQuestion: '不具合報告＆機能要望',
 
+  HTML_lang: 'ja',
+  HTML_availableFirefoxSafariChrome: 'Firefox, Safari, Chromeで再生可能',
+  HTML_cantAnimateOnIE: 'IEではアニメは再生できません',
+  HTML_cantViewOnIE: 'IEでは表示できません',
+  HTML_forWebpSupportedBrowsers: 'webp対応ブラウザ用',
+  HTML_forWebpUnsupportedBrowsers: 'webp非対応ブラウザ用',
+  HTML_backgroundCssComment: 'プレビュー背景のチェック模様をCSSで表示する',
+
   VALIDATE_ImportImageSize:
     'の幅・高さが他の画像と異なっています。連番画像のサイズが統一されているか確認ください。',
   VALIDATE_title:

--- a/product/main-src/generators/generateHtml.ts
+++ b/product/main-src/generators/generateHtml.ts
@@ -1,56 +1,51 @@
 import * as fs from 'fs';
 import { AnimationImageOptions } from '../../common-src/data/animation-image-option';
-
-const backgroundImageUrl =
-  'https://raw.githubusercontent.com/ics-creative/160609_animation-image-generator/master/app/imgs/opacity.png';
-
-const scriptElementLoadPolitill = `<script src="https://cdnjs.cloudflare.com/ajax/libs/apng-canvas/2.1.1/apng-canvas.min.js"></script>`;
-const scriptElementEnablePolifill = `
-    <script>
-      if(window.navigator.userAgent.indexOf("Chrome") >= 0 && window.navigator.userAgent.indexOf("Edge") == -1){
-        // Chrome の場合は WebP ファイルが表示される
-      }else{
-        // Chrome 以外の場合は APNG 利用可否を判定する
-        APNG.ifNeeded().then(function () {
-          // APNG に未対応のブラウザ(例：IE, Edge)では、JSライブラリ「apng-canvas」により表示可能にする
-          var images = document.querySelectorAll(".apng-image");
-          for (var i = 0; i < images.length; i++){ APNG.animateImage(images[i]); }
-        });
-      }
-    </script>`;
+import { localeData } from '../locale-manager';
 
 const createImageElementApng = (
   filePNGName: string,
   width: number,
   height: number
-) => `
-    <!-- Firefox と Safari で再生可能 (Chrome, IE, Edge ではアニメは再生できません) -->
-    <img src="${filePNGName}" width="${width}"
-    height="${height}" alt="" class="apng-image" />`;
+) => `<!-- ${localeData().HTML_availableFirefoxSafariChrome} (${localeData().HTML_cantAnimateOnIE}) -->
+      <img 
+        src="${filePNGName}" 
+        width="${width}"
+        height="${height}"
+        alt=""
+        class="preview-image"
+      />`;
 
 const createImageElementWebP = (
   fileWebPName: string,
   width: number,
   height: number
-) => `
-    <!-- Chrome で再生可能 (IE, Edge, Firefox, Safari では表示できません) -->
-    <img src="${fileWebPName}" width="${width}"
-    height="${height}" alt="" />`;
+) => `<!-- ${localeData().HTML_availableFirefoxSafariChrome} (${localeData().HTML_cantViewOnIE}) -->
+      <img
+        src="${fileWebPName}"
+        width="${width}"
+        height="${height}"
+        alt=""
+        class="preview-image"
+      />`;
 
 const createImageElementWebpAndApng = (
   fileWebPName: string,
   filePNGName: string,
   width: number,
   height: number
-) => `
-<!-- Chrome と Firefox と Safari で再生可能 (IE, Edge ではアニメは再生できません) -->
-<picture>
-<!-- Chrome 用 -->
-  <source type="image/webp" srcset="${fileWebPName}" />
-  <!-- Firefox, Safari 用 -->
-  <img src="${filePNGName}" width="${width}"
-  height="${height}" alt="" class="apng-image" />
-</picture>`;
+) => `<!-- ${localeData().HTML_availableFirefoxSafariChrome} (${localeData().HTML_cantAnimateOnIE}) -->
+      <picture>
+        <!-- ${localeData().HTML_forWebpSupportedBrowsers} -->
+        <source type="image/webp" srcset="${fileWebPName}" />
+        <!-- ${localeData().HTML_forWebpUnsupportedBrowsers} -->
+        <img
+          src="${filePNGName}"
+          width="${width}"
+          height="${height}"
+          alt=""
+          class="preview-image"
+        />
+      </picture>`;
 
 /**
  * HTMLファイルを作成します。
@@ -89,24 +84,29 @@ export const generateHtml = (
 
   // tslint:disable-next-line:max-line-length
   const data = `<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8" />
-    <style>
-      /* 確認用のCSS */
-      body { background: #444; }
-      picture img, .apng-image
-      {
-        background: url(${backgroundImageUrl});
-      }
-    </style>
-    ${scriptElementLoadPolitill}
-  </head>
-  <body>
-  	${imageElement}
-  	${scriptElementEnablePolifill}
-  </body>
-</html>`;
+  <html lang="${localeData().HTML_lang}">
+    <head>
+      <meta charset="utf8" />
+      <style>
+        body {
+          background: #444;
+        }
+        .preview-image {
+          background-color: white;
+          /* ${localeData().HTML_backgroundCssComment} */
+          background-image: 
+              linear-gradient(45deg, #d3d3d3 25%, transparent 25%, transparent 75%, #d3d3d3 75%),
+              linear-gradient(45deg, #d3d3d3 25%, transparent 25%, transparent 75%, #d3d3d3 75%);
+          background-position: 0 0, 8px 8px;
+          background-size: 16px 16px;
+        }
+      </style>
+    </head>
+    <body>
+      ${imageElement}
+    </body>
+  </html>
+`;
 
   fs.writeFileSync(exportFilePath, data);
 };


### PR DESCRIPTION
#27 の対応を行いました。

■ 方針
- IEの対応は切る
- 基本的にChrome, Firefox, Safariの新しいバージョンがターゲット
  - Safari13など、webp未対応ブラウザではapngにフォールバックする

■ 修正概要
- IE/古いChrome向けに入れていたapng再生ライブラリを削除
- 背景の市松模様をリポジトリの画像直参照からCSSグラデーションによる描画に変更
- htmlのコメント等の文言を日英切り替え＆英訳追加
- ツールチップの画像形式の説明が古かったので、html内の説明に沿う形で最新化＆英訳がなかったので追加
