### PR TITLE
バリデーションの種類をUIから選択できるように修正

### DIFF
--- a/product/src/app/app.module.ts
+++ b/product/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 
 import { AppComponent } from './components/app/app';
 import { AnimPreviewComponent } from './components/anim-preview/anim-preview';
@@ -19,7 +19,7 @@ import {TooltipComponent} from "./components/tooltip/tooltip";
 
 @NgModule({
   declarations: [AppComponent, AnimPreviewComponent, PropertiesComponent,TooltipComponent],
-  imports: [BrowserModule, FormsModule],
+  imports: [BrowserModule, FormsModule, ReactiveFormsModule],
   providers: [IpcService],
   bootstrap: [AppComponent]
 })

--- a/product/src/app/components/anim-preview/anim-preview.ts
+++ b/product/src/app/components/anim-preview/anim-preview.ts
@@ -41,6 +41,9 @@ export class AnimPreviewComponent implements OnChanges, OnInit {
   @Input()
   openingDirectories = false;
 
+  @Input()
+  checkRule:LineValidationType = LineValidationType.ANIMATION_STAMP
+
   @ViewChild('tooltipElement')
   tooltipElement: ElementRef | undefined;
 
@@ -113,12 +116,10 @@ export class AnimPreviewComponent implements OnChanges, OnInit {
 
   private loop(): void {
     createjs.Ticker.framerate = this.animationOptionData.fps;
-
     // ここでバリデートするのは間違っていると思うが・・・・
     if (this.animationOptionData.preset === PresetType.LINE) {
-      // TODO: バリデーションの種類をUIで指定できるようにする
       this.validationErrors = validateLineStamp(
-        LineValidationType.ANIMATION_STAMP,
+        this.checkRule,
         this.animationOptionData
       );
     } else {

--- a/product/src/app/components/app/app.html
+++ b/product/src/app/components/app/app.html
@@ -41,9 +41,8 @@
       <div class="checkRule mod-select-preset">
         <p class="mb-2">{{ localeData.RULE_title }}</p>
         <select
-          #checkRuleSelector
-          (change)="handleCheckRuleChange(checkRuleSelector.value)"
           class="form-control mb-4"
+          [formControl]="checkRule"
         >
           <option *ngFor="let checkRule of checkRuleList" [value]="checkRule">
             {{ checkRuleLabel[checkRule] }}
@@ -69,6 +68,7 @@
     <app-anim-preview
       [animationOptionData]="animationOptionData"
       [items]="items"
+      [checkRule]="checkRule.value"
       [openingDirectories]="isUiLocked"
       (clickFileSelectButtonEvent)="handleClickFileSelectButton()"
       (showTooltipEvent)="changeTooltipShowing($event)"

--- a/product/src/app/components/app/app.ts
+++ b/product/src/app/components/app/app.ts
@@ -173,8 +173,7 @@ export class AppComponent implements OnInit, AfterViewInit {
         AppConfig.version,
         this.items,
         this.animationOptionData,
-        // TODO: バリデーションの種類はUIから指定できるようにする
-        LineValidationType.ANIMATION_STAMP
+        this.checkRule.value
       );
     } finally {
       this.hideLockDialog();

--- a/product/src/app/components/app/app.ts
+++ b/product/src/app/components/app/app.ts
@@ -20,6 +20,7 @@ import { localeData } from 'app/i18n/locale-manager';
 import { LineValidationType } from '../../../../common-src/type/LineValidationType';
 import { checkRuleList } from '../../../../common-src/checkRule/checkRule';
 import { Tooltip } from '../../../../common-src/type/TooltipType';
+import {FormControl} from "@angular/forms";
 
 const getFirstNumber = (text: string): number | undefined => {
   const numStr = text.match(/\d+/g)?.pop();
@@ -54,6 +55,7 @@ export class AppComponent implements OnInit, AfterViewInit {
     x: 0,
     y: 0
   };
+  checkRule = new FormControl(LineValidationType.ANIMATION_STAMP);
 
   readonly checkRuleList = checkRuleList;
   readonly checkRuleLabel = {
@@ -121,10 +123,6 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.presetMode = preset;
 
     this.changePreset(this.presetMode);
-  }
-
-  handleCheckRuleChange(rule: string) {
-    console.log(rule);
   }
 
   changePreset(presetMode: PresetType) {


### PR DESCRIPTION
Lineスタンプのバリデーション設定を「チェックルール」の選択したものと連携するようにしました。

暫定的に設置していた`handleCheckRuleChange()`は不要になったので削除しています。

ツールチップとの連携は別タスクで行う予定です。

ご確認おねがいします。