### PR TITLE
ループ回数をバリデーションに表示

### DIFF
--- a/product/src/app/components/anim-preview/anim-preview.html
+++ b/product/src/app/components/anim-preview/anim-preview.html
@@ -44,23 +44,6 @@
     <span class="ml-2" *ngIf="animationOptionData.noLoop === false">/</span>
     <span class="ml-2" *ngIf="animationOptionData.noLoop === false">
       <span>
-        {{ localeData.PREV_infoTime }}
-        <span
-          class="badge badge-success"
-          [ngClass]="{
-            'badge-success': !validationErrors.durationError,
-            'badge-danger': validationErrors.durationError
-          }"
-          >{{
-            (items.length * animationOptionData.loop) / animationOptionData.fps
-          }}{{ localeData.PREV_infoTimeUnit }}</span
-        >
-      </span></span
-    >
-
-    <span class="ml-2" *ngIf="animationOptionData.noLoop === false">/</span>
-    <span class="ml-2" *ngIf="animationOptionData.noLoop === false">
-      <span>
         {{ localeData.PROP_tabAnimLoopNum }}
         <span
           class="badge badge-success"
@@ -68,7 +51,24 @@
             'badge-success': !validationErrors.loopCountError,
             'badge-danger': validationErrors.loopCountError
           }"
-          >{{ animationOptionData.loop }}</span
+        >{{ animationOptionData.loop }}</span
+        >
+      </span></span
+    >
+
+    <span class="ml-2" *ngIf="animationOptionData.noLoop === false">/</span>
+    <span class="ml-2" *ngIf="animationOptionData.noLoop === false">
+      <span>
+        {{ localeData.PREV_infoTime }}
+        <span
+          class="badge badge-success"
+          [ngClass]="{
+            'badge-success': !validationErrors.durationError,
+            'badge-danger': validationErrors.durationError
+          }"
+        >{{
+          (items.length * animationOptionData.loop) / animationOptionData.fps
+          }}{{ localeData.PREV_infoTimeUnit }}</span
         >
       </span></span
     >

--- a/product/src/app/components/anim-preview/anim-preview.html
+++ b/product/src/app/components/anim-preview/anim-preview.html
@@ -51,7 +51,7 @@
             'badge-success': !validationErrors.loopCountError,
             'badge-danger': validationErrors.loopCountError
           }"
-        >{{ animationOptionData.loop }}</span
+          >{{ animationOptionData.loop }}</span
         >
       </span></span
     >
@@ -66,9 +66,7 @@
             'badge-success': !validationErrors.durationError,
             'badge-danger': validationErrors.durationError
           }"
-        >{{
-          (items.length * animationOptionData.loop) / animationOptionData.fps
-          }}{{ localeData.PREV_infoTimeUnit }}</span
+          >{{ durationTime }}{{ localeData.PREV_infoTimeUnit }}</span
         >
       </span></span
     >

--- a/product/src/app/components/anim-preview/anim-preview.html
+++ b/product/src/app/components/anim-preview/anim-preview.html
@@ -41,9 +41,9 @@
         >{{ items.length }}</span
       ></span
     >
-    <span class="ml-2">/</span>
-    <span class="ml-2">
-      <span *ngIf="animationOptionData.noLoop === false">
+    <span class="ml-2" *ngIf="animationOptionData.noLoop === false">/</span>
+    <span class="ml-2" *ngIf="animationOptionData.noLoop === false">
+      <span>
         {{ localeData.PREV_infoTime }}
         <span
           class="badge badge-success"
@@ -58,7 +58,27 @@
       </span></span
     >
 
-    <button (click)="showTooltip()" #tooltipElement class="ml-2 error-tooltip">
+    <span class="ml-2" *ngIf="animationOptionData.noLoop === false">/</span>
+    <span class="ml-2" *ngIf="animationOptionData.noLoop === false">
+      <span>
+        {{ localeData.PROP_tabAnimLoopNum }}
+        <span
+          class="badge badge-success"
+          [ngClass]="{
+            'badge-success': !validationErrors.loopCountError,
+            'badge-danger': validationErrors.loopCountError
+          }"
+          >{{ animationOptionData.loop }}</span
+        >
+      </span></span
+    >
+
+    <button
+      *ngIf="hasError"
+      (click)="showTooltip()"
+      #tooltipElement
+      class="ml-2 error-tooltip"
+    >
       <i class="fa fa-exclamation text-white error-tooltip_inner bg-danger"></i>
     </button>
   </p>

--- a/product/src/app/components/anim-preview/anim-preview.ts
+++ b/product/src/app/components/anim-preview/anim-preview.ts
@@ -19,9 +19,13 @@ import {
   validateLineStampNoError
 } from '../../../../common-src/validators/validateLineStamp';
 import { localeData } from 'app/i18n/locale-manager';
-import { ImageValidatorResult } from '../../../../common-src/type/ImageValidator';
+import {
+  ImageValidatorResult,
+  ValidationResult
+} from '../../../../common-src/type/ImageValidator';
 import { LineValidationType } from '../../../../common-src/type/LineValidationType';
 import { Tooltip } from '../../../../common-src/type/TooltipType';
+import { error } from 'jquery';
 
 @Component({
   selector: 'app-anim-preview',
@@ -70,6 +74,11 @@ export class AnimPreviewComponent implements OnChanges, OnInit {
 
   selectScaleValue(scaleValue: string): void {
     this.scaleValue = Number(scaleValue);
+  }
+
+  get hasError() {
+    const errors: ValidationResult[] = Object.values(this.validationErrors);
+    return errors.some((errorMessage) => errorMessage !== undefined);
   }
 
   ngOnInit() {

--- a/product/src/app/components/anim-preview/anim-preview.ts
+++ b/product/src/app/components/anim-preview/anim-preview.ts
@@ -76,9 +76,21 @@ export class AnimPreviewComponent implements OnChanges, OnInit {
     this.scaleValue = Number(scaleValue);
   }
 
+  /** バリデーションエラーがあるか返します */
   get hasError() {
     const errors: ValidationResult[] = Object.values(this.validationErrors);
     return errors.some((errorMessage) => errorMessage !== undefined);
+  }
+
+  /** 再生時間を小数第二位で四捨五入して返します */
+  get durationTime() {
+    return (
+      Math.round(
+        ((this.items.length * this.animationOptionData.loop) /
+          this.animationOptionData.fps) *
+          100
+      ) / 100
+    );
   }
 
   ngOnInit() {

--- a/product/src/app/components/anim-preview/anim-preview.ts
+++ b/product/src/app/components/anim-preview/anim-preview.ts
@@ -25,7 +25,6 @@ import {
 } from '../../../../common-src/type/ImageValidator';
 import { LineValidationType } from '../../../../common-src/type/LineValidationType';
 import { Tooltip } from '../../../../common-src/type/TooltipType';
-import { error } from 'jquery';
 
 @Component({
   selector: 'app-anim-preview',


### PR DESCRIPTION
以下の機能を追加しました。

- ループ回数のバリデーション表示を追加
- ループ回数と再生時間のレイアウト調整
- 再生時間を小数点第二位で四捨五入
- エラーがあるときのみ、ツールチップアイコンを表示（内容との連携は別タスク予定です）

ご確認おねがいします。

![スクリーンショット 2022-04-08 17 10 47](https://user-images.githubusercontent.com/48976682/162401672-36055fb2-acee-4472-83f4-db24b2236b30.png)

![スクリーンショット 2022-04-08 17 55 11](https://user-images.githubusercontent.com/48976682/162401792-8e1f2bf4-c717-4283-a3e5-9e2a15af304d.png)


