### PR TITLE
バリデーション機能とメッセージの連携

### DIFF
--- a/product/common-src/validators/validationFunctions/validateDuration.ts
+++ b/product/common-src/validators/validationFunctions/validateDuration.ts
@@ -16,6 +16,6 @@ export const validateDuration = (
     : {
         message: getLocaleData().VALIDATE_time({
           valids: validSecs.join(getLocaleData().COMMON_listingConnma),
-          current: sec
+          current: Math.round(sec * 100) / 100
         })
       };

--- a/product/src/app/components/anim-preview/anim-preview.ts
+++ b/product/src/app/components/anim-preview/anim-preview.ts
@@ -60,6 +60,9 @@ export class AnimPreviewComponent implements OnChanges, OnInit {
   @Output()
   buttonPos = new EventEmitter<{ x: number; y: number }>();
 
+  @Output()
+  validationErrorMessages = new EventEmitter<ImageValidatorResult>();
+
   imagePath = '';
   playing = false;
   currentFrame = 0;
@@ -145,6 +148,8 @@ export class AnimPreviewComponent implements OnChanges, OnInit {
     } else {
       this.validationErrors = validateLineStampNoError();
     }
+
+    this.validationErrorMessages.emit(this.validationErrors);
 
     if (!this.items || !this.playing) {
       this.playing = false;

--- a/product/src/app/components/app/app.html
+++ b/product/src/app/components/app/app.html
@@ -70,6 +70,7 @@
       (clickFileSelectButtonEvent)="handleClickFileSelectButton()"
       (showTooltipEvent)="changeTooltipShowing($event)"
       (buttonPos)="setLineStampAlertButtonPos($event)"
+      (validationErrorMessages)="setValidationErrorMessages($event)"
     >
     </app-anim-preview>
   </div>
@@ -80,6 +81,7 @@
       [showingTooltip]="showingTooltip"
       [lineStampAlertButtonPos]="lineStampAlertButtonPos"
       (changeTooltipShowing)="changeTooltipShowing($event)"
+      [validationErrorsMessage]="validationErrorsMessage"
     ></app-tooltip>
   </div>
 </div>

--- a/product/src/app/components/app/app.ts
+++ b/product/src/app/components/app/app.ts
@@ -21,6 +21,10 @@ import { LineValidationType } from '../../../../common-src/type/LineValidationTy
 import { checkRuleList } from '../../../../common-src/checkRule/checkRule';
 import { Tooltip } from '../../../../common-src/type/TooltipType';
 import { FormControl } from '@angular/forms';
+import {
+  ImageValidatorResult,
+  ValidationResult
+} from '../../../../common-src/type/ImageValidator';
 
 const getFirstNumber = (text: string): number | undefined => {
   const numStr = text.match(/\d+/g)?.pop();
@@ -49,6 +53,7 @@ export class AppComponent implements OnInit, AfterViewInit {
   items: ImageData[] = [];
   PresetType = PresetType;
   localeData = localeData;
+  validationErrorsMessage = [''];
 
   showingTooltip: Tooltip | null = null;
   lineStampAlertButtonPos: { x: number; y: number } = {
@@ -309,5 +314,11 @@ export class AppComponent implements OnInit, AfterViewInit {
    */
   setLineStampAlertButtonPos(pos: { x: number; y: number }) {
     this.lineStampAlertButtonPos = pos;
+  }
+
+  setValidationErrorMessages(errors: ImageValidatorResult) {
+    this.validationErrorsMessage = (Object.values(errors) as ValidationResult[])
+      .filter((value) => value !== undefined)
+      .map((value) => value?.message ?? '');
   }
 }

--- a/product/src/app/components/tooltip/tooltip.html
+++ b/product/src/app/components/tooltip/tooltip.html
@@ -31,8 +31,9 @@
       以下の<span class="text-danger">エラー</span>があります
     </h3>
     <ul>
-      <li>再生時間が規定を超えています</li>
-      <li>サイズが不一致です</li>
+      <li *ngFor="let message of validationErrorsMessage">
+        {{ message }}
+      </li>
     </ul>
   </div>
 </div>

--- a/product/src/app/components/tooltip/tooltip.ts
+++ b/product/src/app/components/tooltip/tooltip.ts
@@ -22,6 +22,9 @@ export class TooltipComponent {
   @Input()
   lineStampAlertButtonPos = { x: 0, y: 0 };
 
+  @Input()
+  validationErrorsMessage: string[] = [''];
+
   @Output()
   changeTooltipShowing = new EventEmitter<Tooltip | null>();
 


### PR DESCRIPTION
バリデーションエラーのツールチップのテキストをバリデーションメッセージと連携しました。
合わせてバリデーションメッセージ内の時間秒数の小数第二位の四捨五入も修正しています。

ご確認よろしくお願いします。

