### PR TITLE
ループ回数を空にできてしまう不具合の修正

### DIFF
--- a/product/main-src/main.ts
+++ b/product/main-src/main.ts
@@ -35,8 +35,8 @@ const handle: IpcMainHandled = (channel, listener) => {
 const createWindow = () => {
   // メインウィンドウを作成します
   mainWindow = new BrowserWindow({
-    width: 800,
-    height: 600,
+    width: 880,
+    height: 660,
     title: localeData().APP_NAME,
     webPreferences: {
       nodeIntegration: false,

--- a/product/src/app/components/properties/properties.html
+++ b/product/src/app/components/properties/properties.html
@@ -31,6 +31,7 @@
             data-placement="right"
             title="{{ localeData.PROP_tabAnimFpsTooltip }}"
             *ngIf="animationOptionData.preset === PresetType.LINE"
+            (blur)="avoidBlankFpsNum()"
           />
           <input
             type="number"
@@ -39,6 +40,7 @@
             min="1"
             max="60"
             *ngIf="animationOptionData.preset === PresetType.WEB"
+            (blur)="avoidBlankFpsNum()"
           />
         </div>
       </div>

--- a/product/src/app/components/properties/properties.html
+++ b/product/src/app/components/properties/properties.html
@@ -75,6 +75,7 @@
             data-placement="right"
             title="{{ localeData.PROP_tabAnimLoopTooltip }}"
             *ngIf="animationOptionData.preset === PresetType.LINE"
+            (blur)="avoidBlankLoopNum()"
           />
           <input
             type="number"
@@ -82,6 +83,7 @@
             [(ngModel)]="animationOptionData.loop"
             min="1"
             *ngIf="animationOptionData.preset === PresetType.WEB"
+            (blur)="avoidBlankLoopNum()"
           />
         </div>
       </div>

--- a/product/src/app/components/properties/properties.ts
+++ b/product/src/app/components/properties/properties.ts
@@ -27,15 +27,15 @@ export class PropertiesComponent {
   constructor() {}
 
   avoidBlankLoopNum() {
-    // ループ回数が0やnullの場合は1に補正
-    if (!this.animationOptionData.loop) {
+    // ループ回数が0やnull、負数の場合は1に補正
+    if (!this.animationOptionData.loop || this.animationOptionData.loop < 0) {
       this.animationOptionData.loop = 1;
     }
   }
 
   avoidBlankFpsNum() {
-    // FPS回数が0やnullの場合は1に補正
-    if (!this.animationOptionData.fps) {
+    // FPS回数が0やnull、負数の場合は1に補正
+    if (!this.animationOptionData.fps || this.animationOptionData.fps < 0) {
       this.animationOptionData.fps = 1;
     }
   }

--- a/product/src/app/components/properties/properties.ts
+++ b/product/src/app/components/properties/properties.ts
@@ -33,6 +33,13 @@ export class PropertiesComponent {
     }
   }
 
+  avoidBlankFpsNum() {
+    // FPS回数が0やnullの場合は1に補正
+    if (!this.animationOptionData.fps) {
+      this.animationOptionData.fps = 1;
+    }
+  }
+
   showTooltip() {
     this.showTooltipEvent.emit(Tooltip.OPTIMISE);
   }

--- a/product/src/app/components/properties/properties.ts
+++ b/product/src/app/components/properties/properties.ts
@@ -28,14 +28,14 @@ export class PropertiesComponent {
 
   avoidBlankLoopNum() {
     // ループ回数が0やnull、負数の場合は1に補正
-    if (!this.animationOptionData.loop || this.animationOptionData.loop < 0) {
+    if (!(this.animationOptionData.loop > 0)) {
       this.animationOptionData.loop = 1;
     }
   }
 
   avoidBlankFpsNum() {
     // FPS回数が0やnull、負数の場合は1に補正
-    if (!this.animationOptionData.fps || this.animationOptionData.fps < 0) {
+    if (!(this.animationOptionData.loop > 0)) {
       this.animationOptionData.fps = 1;
     }
   }

--- a/product/src/app/components/properties/properties.ts
+++ b/product/src/app/components/properties/properties.ts
@@ -26,6 +26,13 @@ export class PropertiesComponent {
 
   constructor() {}
 
+  avoidBlankLoopNum() {
+    // ループ回数が0やnullの場合は1に補正
+    if (!this.animationOptionData.loop) {
+      this.animationOptionData.loop = 1;
+    }
+  }
+
   showTooltip() {
     this.showTooltipEvent.emit(Tooltip.OPTIMISE);
   }


### PR DESCRIPTION
#45 「FPS・ループ回数の入力欄が空にでき、その状態で保存するとwebp出力がエラーになる」不具合の対応と、ウィンドウサイズの修正を行いました。

空欄にできてしまう問題は`onBluer`時に、0や空欄の場合には1にするような処理を走らせています。

ご確認お願いします。