### PR TITLE
再生ボタンなどの位置を調整

### DIFF
--- a/product/src/app/components/anim-preview/anim-preview.html
+++ b/product/src/app/components/anim-preview/anim-preview.html
@@ -82,12 +82,7 @@
   </p>
 
   <div class="preview-area mb-3">
-    <!-- 1枚画像プレビュー -->
-    <div [ngStyle]="{ zoom: scaleValue }" class="mb-3">
-      <img data-src="file:///{{ imagePath + '?cc=' + cacheClearStamp }}" />
-    </div>
-
-    <div class="d-flex align-items-center">
+    <div class="d-flex align-items-center　mb-3">
       <!-- 再生・停止・戻るボタン -->
       <span class="mr-2 button-group" role="group">
         <button
@@ -138,6 +133,10 @@
       >
         {{ localeData.PREV_btnSelectRe }}
       </button>
+    </div>
+    <!-- 1枚画像プレビュー -->
+    <div [ngStyle]="{ zoom: scaleValue }" class="mb-3">
+      <img data-src="file:///{{ imagePath + '?cc=' + cacheClearStamp }}" />
     </div>
   </div>
 


### PR DESCRIPTION
再生ボタンの位置を調整しました。画像サイズが違うものを選択してもコントロールボタンを操作しやすくなっています。
ご確認お願いします。

![スクリーンショット 2022-04-20 16 25 18](https://user-images.githubusercontent.com/48976682/164198995-0512244b-85c2-4885-9370-c0d4671daf43.png)
　