### PR TITLE
ツールチップのテキストを国際化

### DIFF
--- a/product/common-src/i18n/locale-data.interface.ts
+++ b/product/common-src/i18n/locale-data.interface.ts
@@ -26,6 +26,7 @@ export interface ILocaleData {
   PROP_tabQualityApngOpt: string;
   PROP_tabQualityOptWay: string;
 
+  PROP_tabQualityAboutOpt: string;
   PROP_tabQualityApngOptTooltip: string;
   PROP_tabQualityOptWayZopfli: string;
   PROP_tabQualityOptWay7zip: string;

--- a/product/common-src/i18n/locale-data.interface.ts
+++ b/product/common-src/i18n/locale-data.interface.ts
@@ -106,4 +106,6 @@ export interface ILocaleData {
   RULE_popup: string;
   RULE_effect: string;
   RULE_emoji: string;
+
+  TOOLTIP_error_title: string;
 }

--- a/product/common-src/i18n/localeDataEn.ts
+++ b/product/common-src/i18n/localeDataEn.ts
@@ -23,10 +23,10 @@ export const localeDataEn: ILocaleData = {
   PROP_tabQualityOptWay: 'Compression Method',
 
   PROP_tabQualityAboutOpt:"What's Optimization?",
-  PROP_tabQualityApngOptTooltip: 'Reduce the image quality to reduce the file size',
-  PROP_tabQualityOptWayZopfli: 'It is the smallest file size, but the file saving is very long. In some cases, it can take over a few minutes.',
-  PROP_tabQualityOptWay7zip: 'Make file size smaller, but file saving takes longer.',
-  PROP_tabQualityOptWayzlib: 'Make file size not much smaller, but file save immediately',
+  PROP_tabQualityApngOptTooltip: 'Compress image to reduce the file size. File size and required time will be changed by the compression method.',
+  PROP_tabQualityOptWayZopfli: 'File size is smallest but saving takes very long time. In some cases, it can take over a few minutes.',
+  PROP_tabQualityOptWay7zip: 'File size is smaller but saving takes long time.',
+  PROP_tabQualityOptWayzlib: 'File size is not much smaller but saved immediately.',
 
   PROP_tabQualityHApng: 'Export as APNG',
   PROP_tabQualityHWebp: 'Export as WebP',
@@ -113,5 +113,5 @@ export const localeDataEn: ILocaleData = {
   RULE_emoji: 'Animated emoji',
 
   // Output as HTML
-  TOOLTIP_error_title: "It has some <span class='text-danger'>Errors</span>"
+  TOOLTIP_error_title: "There are some <span class='text-danger'>Errors</span>"
 };

--- a/product/common-src/i18n/localeDataEn.ts
+++ b/product/common-src/i18n/localeDataEn.ts
@@ -110,5 +110,8 @@ export const localeDataEn: ILocaleData = {
   RULE_animation_main: 'Animated Stickers Main Image',
   RULE_popup: 'Pop-up stickers Image',
   RULE_effect: 'Effect stickers Image',
-  RULE_emoji: 'Animated emoji'
+  RULE_emoji: 'Animated emoji',
+
+  // Output as HTML
+  TOOLTIP_error_title: "It has some <span class='text-danger'>Errors</span>"
 };

--- a/product/common-src/i18n/localeDataEn.ts
+++ b/product/common-src/i18n/localeDataEn.ts
@@ -22,6 +22,7 @@ export const localeDataEn: ILocaleData = {
   PROP_tabQualityApngOpt: 'Optimization',
   PROP_tabQualityOptWay: 'Compression Method',
 
+  PROP_tabQualityAboutOpt:"What's Optimization?",
   PROP_tabQualityApngOptTooltip: 'Reduce the image quality to reduce the file size',
   PROP_tabQualityOptWayZopfli: 'It is the smallest file size, but the file saving is very long. In some cases, it can take over a few minutes.',
   PROP_tabQualityOptWay7zip: 'Make file size smaller, but file saving takes longer.',

--- a/product/common-src/i18n/localeDataEn.ts
+++ b/product/common-src/i18n/localeDataEn.ts
@@ -22,10 +22,10 @@ export const localeDataEn: ILocaleData = {
   PROP_tabQualityApngOpt: 'Optimization',
   PROP_tabQualityOptWay: 'Compression Method',
 
-  PROP_tabQualityApngOptTooltip: '',
-  PROP_tabQualityOptWayZopfli: '',
-  PROP_tabQualityOptWay7zip: '',
-  PROP_tabQualityOptWayzlib: '',
+  PROP_tabQualityApngOptTooltip: 'Reduce the image quality to reduce the file size',
+  PROP_tabQualityOptWayZopfli: 'It is the smallest file size, but the file saving is very long. In some cases, it can take over a few minutes.',
+  PROP_tabQualityOptWay7zip: 'Make file size smaller, but file saving takes longer.',
+  PROP_tabQualityOptWayzlib: 'Make file size not much smaller, but file save immediately',
 
   PROP_tabQualityHApng: 'Export as APNG',
   PROP_tabQualityHWebp: 'Export as WebP',

--- a/product/common-src/i18n/localeDataJa.ts
+++ b/product/common-src/i18n/localeDataJa.ts
@@ -23,18 +23,20 @@ export const localeDataJa: ILocaleData = {
 
   PROP_tabQualityApngOptTooltip: '画質を下げることで、容量を小さくします',
   PROP_tabQualityOptWayZopfli:
-    '容量が最も小さくなりますが、ファイル作成に最も時間がかかります',
+    '容量が最も小さくなりますが、ファイル作成が非常に長くなります。場合によっては分単位の時間がかかります',
   PROP_tabQualityOptWay7zip:
     '容量が小さくなりますが、ファイル作成に時間がかかります',
   PROP_tabQualityOptWayzlib:
-    '容量が大きくなりますが、すぐにファイルが作成されます',
+    '容量はそれほど小さくなりませんが、すぐにファイルが作成されます',
 
   PROP_tabQualityHApng: 'APNGファイル出力',
   PROP_tabQualityHWebp: 'WebPファイル出力',
   PROP_tabQualityHHtml: 'HTMLファイル出力',
 
-  PROP_tabQualityHApngTooltip: 'APNGはほとんどの主要ブラウザーで利用できるアニメ画像形式です',
-  PROP_tabQualityHWebpTooltip: 'WebPはAPNGよりも新しいアニメ画像形式です。古いブラウザー等では表示や再生ができないことがあります',
+  PROP_tabQualityHApngTooltip:
+    'APNGはほとんどの主要ブラウザーで利用できるアニメ画像形式です',
+  PROP_tabQualityHWebpTooltip:
+    'WebPはAPNGよりも新しいアニメ画像形式です。古いブラウザー等では表示や再生ができないことがあります',
   PROP_tabQualityHHtmlTooltip: 'アニメ画像を表示するためのHTMLを作成します',
 
   PROP_btnSave: 'アニメ画像を保存する',

--- a/product/common-src/i18n/localeDataJa.ts
+++ b/product/common-src/i18n/localeDataJa.ts
@@ -21,7 +21,9 @@ export const localeDataJa: ILocaleData = {
   PROP_tabQualityApngOpt: '容量最適化',
   PROP_tabQualityOptWay: '圧縮方式',
 
-  PROP_tabQualityApngOptTooltip: '画質を下げることで、容量を小さくします',
+  PROP_tabQualityAboutOpt: '容量最適化とは...？',
+  PROP_tabQualityApngOptTooltip:
+    'ファイルを圧縮し容量を最適化します。圧縮方式により処理時間や容量が変わります。',
   PROP_tabQualityOptWayZopfli:
     '容量が最も小さくなりますが、ファイル作成が非常に長くなります。場合によっては分単位の時間がかかります',
   PROP_tabQualityOptWay7zip:

--- a/product/common-src/i18n/localeDataJa.ts
+++ b/product/common-src/i18n/localeDataJa.ts
@@ -117,5 +117,8 @@ export const localeDataJa: ILocaleData = {
   RULE_animation_main: 'アニメーションスタンプメイン画像',
   RULE_popup: 'ポップアップスタンプ画像',
   RULE_effect: 'エフェクトスタンプ画像',
-  RULE_emoji: 'アニメーション絵文字'
+  RULE_emoji: 'アニメーション絵文字',
+
+  // HTMLとして出力
+  TOOLTIP_error_title: "以下の<span class='text-danger'>エラー</span>があります"
 };

--- a/product/src/app/components/anim-preview/anim-preview.html
+++ b/product/src/app/components/anim-preview/anim-preview.html
@@ -82,7 +82,7 @@
   </p>
 
   <div class="preview-area mb-3">
-    <div class="d-flex align-items-center　mb-3">
+    <div class="d-flex align-items-center mb-3">
       <!-- 再生・停止・戻るボタン -->
       <span class="mr-2 button-group" role="group">
         <button

--- a/product/src/app/components/anim-preview/anim-preview.ts
+++ b/product/src/app/components/anim-preview/anim-preview.ts
@@ -193,8 +193,8 @@ export class AnimPreviewComponent implements OnChanges, OnInit {
   showTooltip() {
     this.showTooltipEvent.emit(Tooltip.LINE_STAMP_ALERT);
     this.buttonPos.emit({
-      x: this.tooltipElement?.nativeElement.offsetLeft,
-      y: this.tooltipElement?.nativeElement.offsetTop
+      x: this.tooltipElement?.nativeElement.getBoundingClientRect().x,
+      y: this.tooltipElement?.nativeElement.getBoundingClientRect().y
     });
   }
 }

--- a/product/src/app/components/app/app.html
+++ b/product/src/app/components/app/app.html
@@ -33,6 +33,7 @@
     <app-properties
       [animationOptionData]="animationOptionData"
       (showTooltipEvent)="changeTooltipShowing($event)"
+      (buttonPos)="setShowingTooltipButtonPos($event)"
     ></app-properties>
     <hr />
 
@@ -69,7 +70,7 @@
       [openingDirectories]="isUiLocked"
       (clickFileSelectButtonEvent)="handleClickFileSelectButton()"
       (showTooltipEvent)="changeTooltipShowing($event)"
-      (buttonPos)="setLineStampAlertButtonPos($event)"
+      (buttonPos)="setShowingTooltipButtonPos($event)"
       (validationErrorMessages)="setValidationErrorMessages($event)"
     >
     </app-anim-preview>
@@ -79,7 +80,7 @@
   <div>
     <app-tooltip
       [showingTooltip]="showingTooltip"
-      [lineStampAlertButtonPos]="lineStampAlertButtonPos"
+      [showingTooltipButtonPos]="showingTooltipButtonPos"
       (changeTooltipShowing)="changeTooltipShowing($event)"
       [validationErrorsMessage]="validationErrorsMessage"
     ></app-tooltip>

--- a/product/src/app/components/app/app.ts
+++ b/product/src/app/components/app/app.ts
@@ -56,7 +56,7 @@ export class AppComponent implements OnInit, AfterViewInit {
   validationErrorsMessage = [''];
 
   showingTooltip: Tooltip | null = null;
-  lineStampAlertButtonPos: { x: number; y: number } = {
+  showingTooltipButtonPos: { x: number; y: number } = {
     x: 0,
     y: 0
   };
@@ -310,10 +310,10 @@ export class AppComponent implements OnInit, AfterViewInit {
   }
 
   /**
-   * ラインスタンプの警告ツールチップの位置をセットします
+   * ツールチップの表示位置をセットします
    */
-  setLineStampAlertButtonPos(pos: { x: number; y: number }) {
-    this.lineStampAlertButtonPos = pos;
+  setShowingTooltipButtonPos(pos: { x: number; y: number }) {
+    this.showingTooltipButtonPos = pos;
   }
 
   setValidationErrorMessages(errors: ImageValidatorResult) {

--- a/product/src/app/components/properties/properties.html
+++ b/product/src/app/components/properties/properties.html
@@ -132,7 +132,11 @@
             />
             {{ localeData.PROP_tabQualityApngOpt }}
           </label>
-          <button (click)="showTooltip()" class="ml-2 optimise-tooltip">
+          <button
+            (click)="showTooltip()"
+            #tooltipElement
+            class="ml-2 optimise-tooltip"
+          >
             <i class="optimise-tooltip_inner fa fa-question-circle"></i>
           </button>
         </div>

--- a/product/src/app/components/properties/properties.ts
+++ b/product/src/app/components/properties/properties.ts
@@ -1,4 +1,11 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  Output,
+  ViewChild
+} from '@angular/core';
 import { localeData } from 'app/i18n/locale-manager';
 import { AnimationImageOptions } from '../../../../common-src/data/animation-image-option';
 import { CompressionType } from '../../../../common-src/type/CompressionType';
@@ -18,7 +25,13 @@ export class PropertiesComponent {
   animationOptionData = new AnimationImageOptions();
 
   @Output()
+  buttonPos = new EventEmitter<{ x: number; y: number }>();
+
+  @Output()
   showTooltipEvent = new EventEmitter<Tooltip>();
+
+  @ViewChild('tooltipElement')
+  tooltipElement: ElementRef | undefined;
 
   PresetType = PresetType;
   CompressionType = CompressionType;
@@ -42,5 +55,9 @@ export class PropertiesComponent {
 
   showTooltip() {
     this.showTooltipEvent.emit(Tooltip.OPTIMISE);
+    this.buttonPos.emit({
+      x: this.tooltipElement?.nativeElement.getBoundingClientRect().x,
+      y: this.tooltipElement?.nativeElement.getBoundingClientRect().y
+    });
   }
 }

--- a/product/src/app/components/tooltip/tooltip.html
+++ b/product/src/app/components/tooltip/tooltip.html
@@ -29,9 +29,10 @@
       'top.px': getLineStampAlertButtonPos.y
     }"
   >
-    <h3 class="h6 font-weight-bold">
-      以下の<span class="text-danger">エラー</span>があります
-    </h3>
+    <h3
+      class="h6 font-weight-bold"
+      [innerHTML]="localeData.TOOLTIP_error_title"
+    ></h3>
     <ul>
       <li *ngFor="let message of validationErrorsMessage">
         {{ message }}

--- a/product/src/app/components/tooltip/tooltip.html
+++ b/product/src/app/components/tooltip/tooltip.html
@@ -13,9 +13,9 @@
       ファイルを圧縮し容量を最適化します。圧縮方式により処理時間や容量が変わります。
     </p>
     <ul>
-      <li>zopfli...高い圧縮率のかわり非常に長い処理時間</li>
-      <li>7zip...そこそこの圧縮率とそれなりの処理時間</li>
-      <li>7lib...圧縮率は低いが処理時間が短い</li>
+      <li>zopfli...{{ localeData.PROP_tabQualityOptWayZopfli }}</li>
+      <li>7zip...{{ localeData.PROP_tabQualityOptWay7zip }}</li>
+      <li>7lib...{{ localeData.PROP_tabQualityOptWayzlib }}</li>
     </ul>
   </div>
   <div

--- a/product/src/app/components/tooltip/tooltip.html
+++ b/product/src/app/components/tooltip/tooltip.html
@@ -8,9 +8,11 @@
     #element
     [ngClass]="{ active: isShowingOptimiseTooltip }"
   >
-    <h3 class="h6 font-weight-bold">容量最適化とは...？</h3>
+    <h3 class="h6 font-weight-bold">
+      {{ localeData.PROP_tabQualityAboutOpt }}
+    </h3>
     <p>
-      ファイルを圧縮し容量を最適化します。圧縮方式により処理時間や容量が変わります。
+      {{ localeData.PROP_tabQualityApngOptTooltip }}
     </p>
     <ul>
       <li>zopfli...{{ localeData.PROP_tabQualityOptWayZopfli }}</li>

--- a/product/src/app/components/tooltip/tooltip.html
+++ b/product/src/app/components/tooltip/tooltip.html
@@ -7,6 +7,10 @@
     class="tooltip optimise-tip"
     #element
     [ngClass]="{ active: isShowingOptimiseTooltip }"
+    [ngStyle]="{
+      'left.px': getOptimiseTooltipButtonPos.x,
+      'top.px': getOptimiseTooltipButtonPos.y
+    }"
   >
     <h3 class="h6 font-weight-bold">
       {{ localeData.PROP_tabQualityAboutOpt }}

--- a/product/src/app/components/tooltip/tooltip.ts
+++ b/product/src/app/components/tooltip/tooltip.ts
@@ -6,6 +6,7 @@ import {
   Output,
   ViewChild
 } from '@angular/core';
+import { localeData } from 'app/i18n/locale-manager';
 import { Tooltip } from '../../../../common-src/type/TooltipType';
 
 @Component({
@@ -27,6 +28,8 @@ export class TooltipComponent {
 
   @Output()
   changeTooltipShowing = new EventEmitter<Tooltip | null>();
+
+  localeData = localeData;
 
   hideTooltip(event: MouseEvent) {
     if (!(event.target instanceof HTMLElement)) {

--- a/product/src/app/components/tooltip/tooltip.ts
+++ b/product/src/app/components/tooltip/tooltip.ts
@@ -21,7 +21,7 @@ export class TooltipComponent {
   showingTooltip: Tooltip | null = null;
 
   @Input()
-  lineStampAlertButtonPos = { x: 0, y: 0 };
+  showingTooltipButtonPos = { x: 0, y: 0 };
 
   @Input()
   validationErrorsMessage: string[] = [''];
@@ -48,14 +48,25 @@ export class TooltipComponent {
     return this.showingTooltip === Tooltip.LINE_STAMP_ALERT;
   }
 
+  get getOptimiseTooltipButtonPos() {
+    // ボタン位置とのx座標の差
+    const DIFF_X = 36;
+    // ボタン位置とのy座標の差
+    const DIFF_Y = -14;
+    return {
+      x: this.showingTooltipButtonPos.x + DIFF_X,
+      y: this.showingTooltipButtonPos.y + DIFF_Y
+    };
+  }
+
   get getLineStampAlertButtonPos() {
     // ボタン位置とのx座標の差
     const DIFF_X = -234;
     // ボタン位置とのy座標の差
     const DIFF_Y = 36;
     return {
-      x: this.lineStampAlertButtonPos.x + DIFF_X,
-      y: this.lineStampAlertButtonPos.y + DIFF_Y
+      x: this.showingTooltipButtonPos.x + DIFF_X,
+      y: this.showingTooltipButtonPos.y + DIFF_Y
     };
   }
 }


### PR DESCRIPTION
仮テキストでハードコードされていたツールチップのテキストを国際化対応しました。

エラー部分のタイトルについてはHTMLを含む文字列で、innerHTMLを用いて挿入しています。

ご確認お願いします。