### PR TITLE
ログ修正：送出するエラーログに外部コマンド失敗時の標準出力を追加する

### DIFF
--- a/product/common-src/config/app-config.ts
+++ b/product/common-src/config/app-config.ts
@@ -1,4 +1,4 @@
-const version = '4.1'
+const version = '4.2.test'
 /**
  * アプリケーションの情報を提供します。
  */

--- a/product/common-src/ipc-id.ts
+++ b/product/common-src/ipc-id.ts
@@ -23,7 +23,8 @@ interface IpcInvokeFuncs {
     code: string,
     category: string,
     title: string,
-    detail: string
+    detail: string,
+    stack: string,
   ) => Promise<void>;
   [IpcId.EXEC_IMAGE_EXPORT_PROCESS]: (
     version: string,

--- a/product/main-src/error/error-message.ts
+++ b/product/main-src/error/error-message.ts
@@ -3,13 +3,22 @@ import { ErrorType } from '../../common-src/error/error-type';
 
 declare function require(value: string): any;
 
+/**
+ * 文字列長をmax以内に収めます
+ *
+ * @param text 対象文字列
+ * @param max 最大長
+ * @returns 末尾を切り捨てて"..."を追加した文字列
+ */
+const omitText = (text: string, max: number) =>
+  text.length <= max ? text : text.substring(0, max - 3) + '...';
+
 export class ErrorMessage {
   constructor() {}
   public showErrorMessage(
     errorCode: ErrorType,
     inquiryCode: string,
     errorDetail: string,
-    errorStack: string,
     appName: string,
     window: BrowserWindow
   ): void {
@@ -35,7 +44,7 @@ export class ErrorMessage {
   ): string {
     const errorPhaseMessage = this.getErrorPhaseMessage(errorCode);
     const errorDetailMessage = errorDetail
-      ? '\n\nエラー詳細：' + errorDetail
+      ? '\n\nエラー詳細：' + omitText(errorDetail, 200)
       : '';
     return `${errorPhaseMessage}${errorDetailMessage}
 

--- a/product/main-src/error/send-error.ts
+++ b/product/main-src/error/send-error.ts
@@ -10,15 +10,22 @@ export const sendError = async (
   code: string,
   category: string,
   title: string,
-  detail: string
+  detail: string,
+  stack: string
 ): Promise<void> => {
+  const os = require('os');
+  const osPlatform: string = os.platform();
+  const osArch: string = os.arch();
+  const osRelease: string = os.release();
+
   const saveData = {
-    OS: require('os').platform(),
+    OS: [osPlatform, osArch, osRelease].join('/'),
     version: version,
     code: code,
     category: category,
     title: title,
-    detail: detail
+    detail: detail,
+    stack: stack
   };
 
   const data = {

--- a/product/main-src/file.ts
+++ b/product/main-src/file.ts
@@ -64,18 +64,14 @@ export default class File {
       console.log('::catch-error::');
       // エラー内容の送信
       console.error(error);
-      const detail = JSON.stringify({
-        detail: error.errDetail,
-        name: error.cause.name,
-        stack: error.cause.stack
-      });
 
       sendError(
         version,
         inquiryCode,
         'ERROR',
         error.errCode.toString(),
-        detail
+        error.errDetail,
+        error.cause.stack || ''
       );
 
       this.errorMessage.showErrorMessage(

--- a/product/main-src/file.ts
+++ b/product/main-src/file.ts
@@ -64,21 +64,24 @@ export default class File {
       console.log('::catch-error::');
       // エラー内容の送信
       console.error(error);
-      const errorStack = error.cause.stack;
+      const detail = JSON.stringify({
+        detail: error.errDetail,
+        name: error.cause.name,
+        stack: error.cause.stack
+      });
 
       sendError(
         version,
         inquiryCode,
         'ERROR',
         error.errCode.toString(),
-        errorStack || ''
+        detail
       );
 
       this.errorMessage.showErrorMessage(
         error.errCode,
         inquiryCode,
         error.errDetail,
-        errorStack || '',
         localeData().APP_NAME,
         this.mainWindow
       );

--- a/product/main-src/generators/generateApng.ts
+++ b/product/main-src/generators/generateApng.ts
@@ -49,7 +49,7 @@ export const generateApng = async (
     return {
       cause: err,
       errCode: errorCode,
-      errDetail: stdout
+      errDetail: stdout // stderrの内容はerrに含まれるので、エラー詳細としてはstdoutを返却
     };
   }
 };
@@ -118,6 +118,6 @@ const pngCompress = async (
   return {
     cause: err,
     errCode: errorCode,
-    errDetail: stdout
+    errDetail: stdout // stderrの内容はerrに含まれるので、エラー詳細としてはstdoutを返却
   };
 };

--- a/product/main-src/generators/generateApng.ts
+++ b/product/main-src/generators/generateApng.ts
@@ -86,6 +86,7 @@ const pngCompress = async (
   outDir: string
 ): Promise<GenetateError | undefined> => {
   const options: string[] = [
+    '--verbose',
     '--quality=0-80',
     '--speed',
     '1',

--- a/product/main-src/main.ts
+++ b/product/main-src/main.ts
@@ -148,9 +148,10 @@ handle(
     code: string,
     category: string,
     title: string,
-    detail: string
+    detail: string,
+    stack: string
   ) => {
-    sendError(version, code, category, title, detail);
+    sendError(version, code, category, title, detail, stack);
   }
 );
 

--- a/product/src/app/process/ipc.service.ts
+++ b/product/src/app/process/ipc.service.ts
@@ -36,7 +36,8 @@ export default class IpcService {
     code: string,
     category: string,
     title: string,
-    detail: string
+    detail: string,
+    stack: string
   ) {
     return this.api.invoke(
       IpcId.SEND_ERROR,
@@ -44,7 +45,8 @@ export default class IpcService {
       code,
       category,
       title,
-      detail
+      detail,
+      stack
     );
   }
 


### PR DESCRIPTION
@ics-nohara @ics-nishihara 

従来のログ送出で外部コマンドのエラーを十分に拾えていなかった部分の修正を行いました。

■ 修正概要
- pngquantに詳細ログ出力オプションを追加
  - pngquantはフレームごとの処理でエラーが発生した場合、デフォルトでは何もメッセージを出力せずに終了するようです
  - この対応として、詳細ログを出力する`--verbose`オプションを追加しました→[pngquantのソース](https://github.com/kornelski/pngquant/blob/main/pngquant.c)
  - このパターンで実際にエラーを出す方法を見つけられていないので、チェックは机上のみです
- apngasmのエラー内容をログに追加する
  - 従来は外部コマンド失敗時の結果(err, stdout, stderr)は、err.stackのみが送出されていました
    - err.stackにはエラー発生時のスタックトレースとstderrのエラーメッセージが含まれます
    - 結果としてstdoutの内容はログに含まれていませんでした
    - apngasmのv2.91はstdoutにエラーメッセージを出すようで、この部分が取得できていなかったことになります
  - 対応として、送出ログを明示的に`stack`（=err.stack）と`detail`（=stdout）に分割し、両方を送る形としました
- 画面に表示するエラーメッセージを最長200文字で切るように調整しました
  - 前2項の対応でエラーメッセージがさらに長くなる可能性が出てきたので（元々かなり長くて画面を埋めてしまっていたのですが）最長200文字で切って表示するように修正しました
  - 「200文字」に特に根拠はないので、ご意見ありましたら調整します

■ 確認方法
- 外部コマンドの実行が失敗する（コマンドは起動するが、エラー終了する）ようにして画像保存を行い、ログを確認してください
  - 失敗させる方法例1：コマンドの引数部分のコードをいじって、入力ファイルとして存在しないパスを指すようにする
  - 失敗させる方法例2： コマンド実行直前で実行を停止して、入力ファイルを壊れたデータにすり替える
  - ...など
