### PR TITLE
保存処理前にファイルの存在チェックを追加してわかりやすいエラーを出す

### DIFF
--- a/product/common-src/error/error-type.ts
+++ b/product/common-src/error/error-type.ts
@@ -19,6 +19,7 @@ export enum ErrorType {
 
   MAKE_TEMPORARY_ERROR = 60,
   TEMPORARY_CLEAN_ERROR,
+  INPUT_CHECK_FILE_NOT_FOUND_ERROR, // 入力チェック：ファイルが存在しない
 
   PNG_COMPRESS_ERROR = 70,
   PNG_COMPRESS_ACCESS_ERROR, // 実行ファイルのアクセスに失敗

--- a/product/main-src/error/error-message.ts
+++ b/product/main-src/error/error-message.ts
@@ -108,6 +108,9 @@ export class ErrorMessage {
       // テンポラリファイルの削除
       case ErrorType.TEMPORARY_CLEAN_ERROR:
         return '一時ファイルの削除に失敗しました。';
+
+      case ErrorType.INPUT_CHECK_FILE_NOT_FOUND_ERROR:
+        return '変換元の画像が見つかりません。移動または削除された可能性があります。再度画像を選択して保存をお試しください。';
     }
     return '原因が不明なエラーが発生しました。';
   }

--- a/product/main-src/generators/execGenerate.ts
+++ b/product/main-src/generators/execGenerate.ts
@@ -33,6 +33,10 @@ const copyTemporaryDirectory = async (
   return Promise.all(tasks);
 };
 
+/** 元画像が存在するかチェックし、最初に見つかった存在しない画像を返します。全てが存在する場合は何も返しません */
+const findMissingItemFile = (itemList: ImageData[]): ImageData | undefined =>
+  itemList.find((item) => !fs.existsSync(item.imagePath));
+
 export const execGenerate = async (
   itemList: ImageData[],
   animationOptionData: AnimationImageOptions,
@@ -76,6 +80,14 @@ export const execGenerate = async (
     errorCode = ErrorType.TEMPORARY_CLEAN_ERROR;
     await emptyDirectory(temporaryPath);
     await emptyDirectory(temporaryCompressPath);
+
+    console.log('::check-input-files-exist::');
+    errorCode = ErrorType.INPUT_CHECK_FILE_NOT_FOUND_ERROR;
+    const missing = findMissingItemFile(itemList);
+    if (missing) {
+      errorDetail = 'file not found: ' + missing.imagePath;
+      throw new Error('input file is not exists.');
+    }
 
     console.log('::make-temporary::');
     errorCode = ErrorType.MAKE_TEMPORARY_ERROR;


### PR DESCRIPTION
@ics-nohara @ics-nishihara 

#70 

■ 背景
- 直近のv4.1のエラーログ分析では「Error: ENOENT: no such file or directory, copyfile ユーザーディレクトリ -> テンポラリ」のエラーが全体の20%を占めていました
- このエラーは次の2つのいずれかの要因で発生します：
  - ①入力ファイルが移動・削除された等の理由でアクセスできない
  - ②入力ファイルをテンポラリ領域にコピーしようとしたが、コピー先が容量不足等で書き込めない
- このエラーが発生した場合、ユーザーには「一時ファイルの作成に失敗しました。」と表示される
 
■ 対応方針
①はユーザーの誤った操作（保存前に元ファイルを消した）でも発生するにもかかわらず、そのことがメッセージから理解できないため、①と②を切り分け、①についてはより理解しやすいメッセージを表示します

■ 修正概要
- 保存処理前に入力ファイルの存在チェックを追加しました
- 見つからないファイルがある場合、ファイル名をユーザーに通知します
- この変更により「一時ファイルの作成に失敗しました。」はテンポラリへの書き込み処理が失敗した場合のみに発生するようになります
  - ※ v4.2リリース後に「一時ファイルの作成に失敗しました。」が引き続き多く出ている場合には、テンポラリへの書き込み部分についてもう少し調査・フォローが必要かもしれません

▼ 修正後のエラーメッセージ
![image](https://user-images.githubusercontent.com/59550270/214513573-6c287d9c-bf39-4625-8b74-c5cb5531a0c2.png)

