### PR TITLE
!マークがずれる現象の修正

### DIFF
--- a/product/src/app/components/anim-preview/anim-preview.scss
+++ b/product/src/app/components/anim-preview/anim-preview.scss
@@ -88,6 +88,8 @@
     border-radius: 50%;
     font-size: 12px;
     line-height: 22px;
+    // ウィンドウリサイズで！がズレることがあるのでレンダリングモードを変更させる
+    will-change: transform;
     &:after {
       content: '';
       position: absolute;


### PR DESCRIPTION
！マークが中心からズレる現象があったので、その修正を行いました。原因としてはブラウザのレンダリングによるものと思われるので、`will-change: transform`でGPUレンダリングにするような指定を追加しました。

ご確認お願いします。

▼Before
![スクリーンショット 2023-05-24 10 24 41](https://github.com/ics-creative/160609_animation-image-generator/assets/48976682/182a0bd0-ceed-46d4-bcd0-8501999a9d2f)

▼After
![スクリーンショット 2023-05-24 10 27 02](https://github.com/ics-creative/160609_animation-image-generator/assets/48976682/865683f4-2874-42f6-84db-8e2df1248139)


