### PR TITLE
アニメーション出力設定の状態を保持する

### DIFF
--- a/product/common-src/data/animation-image-option.ts
+++ b/product/common-src/data/animation-image-option.ts
@@ -1,11 +1,11 @@
 import { CompressionType } from '../type/CompressionType';
-import { PresetType } from '../type/PresetType';
+import { ImageExportMode } from '../type/ImageExportMode';
 
 /**
  * アニメーション画像のオプション指定を指定するクラスです。
  */
 export class AnimationImageOptions {
-  preset: PresetType = PresetType.WEB;
+  preset: ImageExportMode = ImageExportMode.WEB;
 
   noLoop = false;
   loop = 0;

--- a/product/common-src/data/animation-image-option.ts
+++ b/product/common-src/data/animation-image-option.ts
@@ -5,7 +5,7 @@ import { ImageExportMode } from '../type/ImageExportMode';
  * アニメーション画像のオプション指定を指定するクラスです。
  */
 export class AnimationImageOptions {
-  preset: ImageExportMode = ImageExportMode.WEB;
+  imageExportMode: ImageExportMode = ImageExportMode.WEB;
 
   noLoop = false;
   loop = 0;

--- a/product/common-src/preset/preset-line.ts
+++ b/product/common-src/preset/preset-line.ts
@@ -18,6 +18,6 @@ export class PresetLine {
     data.enabledExportWebp = false;
     data.enabledExportHtml = false;
 
-    data.preset = ImageExportMode.LINE;
+    data.imageExportMode = ImageExportMode.LINE;
   }
 }

--- a/product/common-src/preset/preset-line.ts
+++ b/product/common-src/preset/preset-line.ts
@@ -1,13 +1,21 @@
 import { AnimationImageOptions } from '../data/animation-image-option';
 import { CompressionType } from '../type/CompressionType';
 import { ImageExportMode } from '../type/ImageExportMode';
+import { LineValidationType } from '../type/LineValidationType';
 
 /**
  * LINEアニメーションスタンプのプリセット設定です。
  */
 export class PresetLine {
 
-  static getPreset() {
+  static getPresetVer1() {
+    return {
+      animationOption: PresetLine.getAnimationOptionVer1(),
+      lineValidationType: LineValidationType.ANIMATION_STAMP,
+    }
+  }
+  
+  static getAnimationOptionVer1() {
     const data = new AnimationImageOptions();
     data.noLoop = false;
     data.loop = 4;

--- a/product/common-src/preset/preset-line.ts
+++ b/product/common-src/preset/preset-line.ts
@@ -6,7 +6,9 @@ import { ImageExportMode } from '../type/ImageExportMode';
  * LINEアニメーションスタンプのプリセット設定です。
  */
 export class PresetLine {
-  static setPreset(data: AnimationImageOptions) {
+
+  static getPreset() {
+    const data = new AnimationImageOptions();
     data.noLoop = false;
     data.loop = 4;
     // data.iterations = 15;
@@ -19,5 +21,6 @@ export class PresetLine {
     data.enabledExportHtml = false;
 
     data.imageExportMode = ImageExportMode.LINE;
+    return data;
   }
 }

--- a/product/common-src/preset/preset-line.ts
+++ b/product/common-src/preset/preset-line.ts
@@ -1,6 +1,6 @@
 import { AnimationImageOptions } from '../data/animation-image-option';
 import { CompressionType } from '../type/CompressionType';
-import { PresetType } from '../type/PresetType';
+import { ImageExportMode } from '../type/ImageExportMode';
 
 /**
  * LINEアニメーションスタンプのプリセット設定です。
@@ -18,6 +18,6 @@ export class PresetLine {
     data.enabledExportWebp = false;
     data.enabledExportHtml = false;
 
-    data.preset = PresetType.LINE;
+    data.preset = ImageExportMode.LINE;
   }
 }

--- a/product/common-src/preset/preset-web.ts
+++ b/product/common-src/preset/preset-web.ts
@@ -1,6 +1,6 @@
 import { CompressionType } from '../type/CompressionType';
 import { AnimationImageOptions } from '../data/animation-image-option';
-import { PresetType } from '../type/PresetType';
+import { ImageExportMode } from '../type/ImageExportMode';
 
 /**
  * Webページ用アニメーションのプリセット設定です。
@@ -18,6 +18,6 @@ export class PresetWeb {
     data.enabledExportWebp = true;
     data.enabledExportHtml = true;
 
-    data.preset = PresetType.WEB;
+    data.preset = ImageExportMode.WEB;
   }
 }

--- a/product/common-src/preset/preset-web.ts
+++ b/product/common-src/preset/preset-web.ts
@@ -6,7 +6,13 @@ import { ImageExportMode } from '../type/ImageExportMode';
  * Webページ用アニメーションのプリセット設定です。
  */
 export class PresetWeb {
-  static getPreset() {
+  static getPresetVer1() {
+    return {
+      animationOption: PresetWeb.getAnimationOptionVer1(),
+    }
+  }
+
+  static getAnimationOptionVer1() {
     const data = new AnimationImageOptions();
     data.noLoop = true;
     data.loop = 4;

--- a/product/common-src/preset/preset-web.ts
+++ b/product/common-src/preset/preset-web.ts
@@ -18,6 +18,6 @@ export class PresetWeb {
     data.enabledExportWebp = true;
     data.enabledExportHtml = true;
 
-    data.preset = ImageExportMode.WEB;
+    data.imageExportMode = ImageExportMode.WEB;
   }
 }

--- a/product/common-src/preset/preset-web.ts
+++ b/product/common-src/preset/preset-web.ts
@@ -6,7 +6,8 @@ import { ImageExportMode } from '../type/ImageExportMode';
  * Webページ用アニメーションのプリセット設定です。
  */
 export class PresetWeb {
-  static setPreset(data: AnimationImageOptions) {
+  static getPreset() {
+    const data = new AnimationImageOptions();
     data.noLoop = true;
     data.loop = 4;
     data.fps = 30;
@@ -19,5 +20,6 @@ export class PresetWeb {
     data.enabledExportHtml = true;
 
     data.imageExportMode = ImageExportMode.WEB;
+    return data;
   }
 }

--- a/product/common-src/type/ImageExportMode.ts
+++ b/product/common-src/type/ImageExportMode.ts
@@ -13,17 +13,6 @@ const IMAGE_EXPORT_MODE_NUM = {
 } as const;
 
 /**
- * 画像出力方法を数値に変換します。
- * この機能はpresetをnumber型で入出力する古い機能との互換性確保のために残されています。
- * 必要な場合のみ使用してください。
- *
- * @param mode
- */
-export function modeToNumber(mode: ImageExportMode) {
-  return IMAGE_EXPORT_MODE_NUM[mode];
-}
-
-/**
  * 数値を画像出力方法名に変換します。
  * この機能は画像出力方法をnumber型で入出力する古い機能との互換性確保のために残されています。
  * 必要な場合のみ使用してください。

--- a/product/common-src/type/ImageExportMode.ts
+++ b/product/common-src/type/ImageExportMode.ts
@@ -1,36 +1,38 @@
 /**
- * プリセットオプションを定義したENUMです。
+ * 画像出力方法を定義したENUMです。
  */
 export enum ImageExportMode {
   LINE = 'line',
   WEB = 'web'
 }
 
-/** Preset名とID(number)の対応表 */
-const PRESET_NUM = {
+/** 画像出力方法名とID(number)の対応表 */
+const IMAGE_EXPORT_MODE_NUM = {
   [ImageExportMode.LINE]: 0,
   [ImageExportMode.WEB]: 1
 } as const;
 
 /**
- * presetを数値に変換します。
+ * 画像出力方法を数値に変換します。
  * この機能はpresetをnumber型で入出力する古い機能との互換性確保のために残されています。
  * 必要な場合のみ使用してください。
  *
- * @param preset
+ * @param mode
  */
-export const presetToNumber = (preset: ImageExportMode) => PRESET_NUM[preset];
+export function modeToNumber(mode: ImageExportMode) {
+  return IMAGE_EXPORT_MODE_NUM[mode];
+}
 
 /**
- * 数値をpreset名に変換します。
- * この機能はpresetをnumber型で入出力する古い機能との互換性確保のために残されています。
+ * 数値を画像出力方法名に変換します。
+ * この機能は画像出力方法をnumber型で入出力する古い機能との互換性確保のために残されています。
  * 必要な場合のみ使用してください。
  *
- * @param presetNum
+ * @param num
  * @returns
  */
-export const numberToPreset = (presetNum: number) => {
-  if (presetNum === PRESET_NUM[ImageExportMode.LINE]) return ImageExportMode.LINE;
-  if (presetNum === PRESET_NUM[ImageExportMode.WEB]) return ImageExportMode.WEB;
+export const numberToMode = (num: number) => {
+  if (num === IMAGE_EXPORT_MODE_NUM[ImageExportMode.LINE]) return ImageExportMode.LINE;
+  if (num === IMAGE_EXPORT_MODE_NUM[ImageExportMode.WEB]) return ImageExportMode.WEB;
   return undefined;
 };

--- a/product/common-src/type/ImageExportMode.ts
+++ b/product/common-src/type/ImageExportMode.ts
@@ -1,15 +1,15 @@
 /**
  * プリセットオプションを定義したENUMです。
  */
-export enum PresetType {
+export enum ImageExportMode {
   LINE = 'line',
   WEB = 'web'
 }
 
 /** Preset名とID(number)の対応表 */
 const PRESET_NUM = {
-  [PresetType.LINE]: 0,
-  [PresetType.WEB]: 1
+  [ImageExportMode.LINE]: 0,
+  [ImageExportMode.WEB]: 1
 } as const;
 
 /**
@@ -19,7 +19,7 @@ const PRESET_NUM = {
  *
  * @param preset
  */
-export const presetToNumber = (preset: PresetType) => PRESET_NUM[preset];
+export const presetToNumber = (preset: ImageExportMode) => PRESET_NUM[preset];
 
 /**
  * 数値をpreset名に変換します。
@@ -30,7 +30,7 @@ export const presetToNumber = (preset: PresetType) => PRESET_NUM[preset];
  * @returns
  */
 export const numberToPreset = (presetNum: number) => {
-  if (presetNum === PRESET_NUM[PresetType.LINE]) return PresetType.LINE;
-  if (presetNum === PRESET_NUM[PresetType.WEB]) return PresetType.WEB;
+  if (presetNum === PRESET_NUM[ImageExportMode.LINE]) return ImageExportMode.LINE;
+  if (presetNum === PRESET_NUM[ImageExportMode.WEB]) return ImageExportMode.WEB;
   return undefined;
 };

--- a/product/common-src/validators/validateLineStamp.test.ts
+++ b/product/common-src/validators/validateLineStamp.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { AnimationImageOptions } from '../data/animation-image-option';
 import { LineValidationType } from '../type/LineValidationType';
-import { PresetType } from '../type/PresetType';
+import { ImageExportMode } from '../type/ImageExportMode';
 import { lineImageValidators } from './lineImageValidators';
 import { validateLineStamp } from './validateLineStamp';
 
@@ -10,7 +10,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for min animation main', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = PresetType.LINE;
+    option.preset = ImageExportMode.LINE;
     option.fps = 5;
     option.loop = 1;
     option.imageInfo.width = 240;
@@ -26,7 +26,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for max animation main', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = PresetType.LINE;
+    option.preset = ImageExportMode.LINE;
     option.fps = 20;
     option.loop = 4;
     option.imageInfo.width = 240;
@@ -44,7 +44,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for min animation stamp', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = PresetType.LINE;
+    option.preset = ImageExportMode.LINE;
     option.fps = 5;
     option.loop = 1;
     option.imageInfo.width = 270;
@@ -63,7 +63,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for max animation stamp', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = PresetType.LINE;
+    option.preset = ImageExportMode.LINE;
     option.fps = 20;
     option.loop = 4;
     option.imageInfo.width = 320;
@@ -84,7 +84,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for min effect stamp', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = PresetType.LINE;
+    option.preset = ImageExportMode.LINE;
     option.fps = 5;
     option.loop = 1;
     option.imageInfo.width = 200;
@@ -100,7 +100,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for max effect stamp', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = PresetType.LINE;
+    option.preset = ImageExportMode.LINE;
     option.fps = 20;
     option.loop = 3;
     option.imageInfo.width = 480;
@@ -118,7 +118,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for min popup stamp', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = PresetType.LINE;
+    option.preset = ImageExportMode.LINE;
     option.fps = 5;
     option.loop = 1;
     option.imageInfo.width = 200;
@@ -134,7 +134,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for max popup stamp', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = PresetType.LINE;
+    option.preset = ImageExportMode.LINE;
     option.fps = 20;
     option.loop = 3;
     option.imageInfo.width = 480;
@@ -152,7 +152,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for min emoji', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = PresetType.LINE;
+    option.preset = ImageExportMode.LINE;
     option.fps = 5;
     option.loop = 1;
     option.imageInfo.width = 180;
@@ -168,7 +168,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for max emoji', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = PresetType.LINE;
+    option.preset = ImageExportMode.LINE;
     option.fps = 20;
     option.loop = 4;
     option.imageInfo.width = 180;

--- a/product/common-src/validators/validateLineStamp.test.ts
+++ b/product/common-src/validators/validateLineStamp.test.ts
@@ -10,7 +10,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for min animation main', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = ImageExportMode.LINE;
+    option.imageExportMode = ImageExportMode.LINE;
     option.fps = 5;
     option.loop = 1;
     option.imageInfo.width = 240;
@@ -26,7 +26,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for max animation main', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = ImageExportMode.LINE;
+    option.imageExportMode = ImageExportMode.LINE;
     option.fps = 20;
     option.loop = 4;
     option.imageInfo.width = 240;
@@ -44,7 +44,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for min animation stamp', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = ImageExportMode.LINE;
+    option.imageExportMode = ImageExportMode.LINE;
     option.fps = 5;
     option.loop = 1;
     option.imageInfo.width = 270;
@@ -63,7 +63,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for max animation stamp', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = ImageExportMode.LINE;
+    option.imageExportMode = ImageExportMode.LINE;
     option.fps = 20;
     option.loop = 4;
     option.imageInfo.width = 320;
@@ -84,7 +84,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for min effect stamp', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = ImageExportMode.LINE;
+    option.imageExportMode = ImageExportMode.LINE;
     option.fps = 5;
     option.loop = 1;
     option.imageInfo.width = 200;
@@ -100,7 +100,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for max effect stamp', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = ImageExportMode.LINE;
+    option.imageExportMode = ImageExportMode.LINE;
     option.fps = 20;
     option.loop = 3;
     option.imageInfo.width = 480;
@@ -118,7 +118,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for min popup stamp', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = ImageExportMode.LINE;
+    option.imageExportMode = ImageExportMode.LINE;
     option.fps = 5;
     option.loop = 1;
     option.imageInfo.width = 200;
@@ -134,7 +134,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for max popup stamp', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = ImageExportMode.LINE;
+    option.imageExportMode = ImageExportMode.LINE;
     option.fps = 20;
     option.loop = 3;
     option.imageInfo.width = 480;
@@ -152,7 +152,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for min emoji', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = ImageExportMode.LINE;
+    option.imageExportMode = ImageExportMode.LINE;
     option.fps = 5;
     option.loop = 1;
     option.imageInfo.width = 180;
@@ -168,7 +168,7 @@ describe('test linestamp validation', () => {
 
   test('should pass for max emoji', () => {
     const option: AnimationImageOptions = new AnimationImageOptions();
-    option.preset = ImageExportMode.LINE;
+    option.imageExportMode = ImageExportMode.LINE;
     option.fps = 20;
     option.loop = 4;
     option.imageInfo.width = 180;

--- a/product/main-src/file.ts
+++ b/product/main-src/file.ts
@@ -51,7 +51,10 @@ export default class File {
     );
 
     // プリセットがLINEの場合、出力成功後にチェックを行い、警告があれば表示
-    if (animationOptionData.imageExportMode === ImageExportMode.LINE && result.pngPath) {
+    if (
+      animationOptionData.imageExportMode === ImageExportMode.LINE &&
+      result.pngPath
+    ) {
       await this.validateLineStamp(
         validationType,
         result.pngPath,

--- a/product/main-src/file.ts
+++ b/product/main-src/file.ts
@@ -3,7 +3,7 @@ import { ErrorMessage } from './error/error-message';
 import { sendError } from './error/send-error';
 import { AnimationImageOptions } from '../common-src/data/animation-image-option';
 import { ImageData } from '../common-src/data/image-data';
-import { PresetType } from '../common-src/type/PresetType';
+import { ImageExportMode } from '../common-src/type/ImageExportMode';
 import { validateLineStamp } from '../common-src/validators/validateLineStamp';
 import * as fs from 'fs';
 import { createInquiryCode } from './generators/createInquiryCode';
@@ -51,7 +51,7 @@ export default class File {
     );
 
     // プリセットがLINEの場合、出力成功後にチェックを行い、警告があれば表示
-    if (animationOptionData.preset === PresetType.LINE && result.pngPath) {
+    if (animationOptionData.preset === ImageExportMode.LINE && result.pngPath) {
       await this.validateLineStamp(
         validationType,
         result.pngPath,

--- a/product/main-src/file.ts
+++ b/product/main-src/file.ts
@@ -50,7 +50,7 @@ export default class File {
       this.saveDialog
     );
 
-    // プリセットがLINEの場合、出力成功後にチェックを行い、警告があれば表示
+    // 出力がLINE向けの場合、出力成功後にチェックを行い、警告があれば表示
     if (
       animationOptionData.imageExportMode === ImageExportMode.LINE &&
       result.pngPath

--- a/product/main-src/file.ts
+++ b/product/main-src/file.ts
@@ -51,7 +51,7 @@ export default class File {
     );
 
     // プリセットがLINEの場合、出力成功後にチェックを行い、警告があれば表示
-    if (animationOptionData.preset === ImageExportMode.LINE && result.pngPath) {
+    if (animationOptionData.imageExportMode === ImageExportMode.LINE && result.pngPath) {
       await this.validateLineStamp(
         validationType,
         result.pngPath,

--- a/product/src/app/components/anim-preview/anim-preview.ts
+++ b/product/src/app/components/anim-preview/anim-preview.ts
@@ -11,7 +11,7 @@ import {
   Output,
   ViewChild
 } from '@angular/core';
-import { PresetType } from '../../../../common-src/type/PresetType';
+import { ImageExportMode } from '../../../../common-src/type/ImageExportMode';
 import { ImageData } from '../../../../common-src/data/image-data';
 import { AnimationImageOptions } from '../../../../common-src/data/animation-image-option';
 import {
@@ -140,7 +140,7 @@ export class AnimPreviewComponent implements OnChanges, OnInit {
   private loop(): void {
     createjs.Ticker.framerate = this.animationOptionData.fps;
     // ここでバリデートするのは間違っていると思うが・・・・
-    if (this.animationOptionData.preset === PresetType.LINE) {
+    if (this.animationOptionData.preset === ImageExportMode.LINE) {
       this.validationErrors = validateLineStamp(
         this.checkRule,
         this.animationOptionData

--- a/product/src/app/components/anim-preview/anim-preview.ts
+++ b/product/src/app/components/anim-preview/anim-preview.ts
@@ -140,7 +140,7 @@ export class AnimPreviewComponent implements OnChanges, OnInit {
   private loop(): void {
     createjs.Ticker.framerate = this.animationOptionData.fps;
     // ここでバリデートするのは間違っていると思うが・・・・
-    if (this.animationOptionData.preset === ImageExportMode.LINE) {
+    if (this.animationOptionData.imageExportMode === ImageExportMode.LINE) {
       this.validationErrors = validateLineStamp(
         this.checkRule,
         this.animationOptionData

--- a/product/src/app/components/app/UserConfig.ts
+++ b/product/src/app/components/app/UserConfig.ts
@@ -1,17 +1,17 @@
 import { AnimationImageOptions } from '../../../../common-src/data/animation-image-option';
 import {
   ImageExportMode,
-  numberToPreset,
-  presetToNumber
+  numberToMode,
+  modeToNumber
 } from '../../../../common-src/type/ImageExportMode';
 
-const PRESET_ID = 'preset_id';
+const IMAGE_EXPORT_MODE = 'preset_id';
 export const loadImageExportMode = (): ImageExportMode => {
-  const presetNum = Number(localStorage.getItem(PRESET_ID));
-  return numberToPreset(presetNum) ?? ImageExportMode.LINE;
+  const presetNum = Number(localStorage.getItem(IMAGE_EXPORT_MODE));
+  return numberToMode(presetNum) ?? ImageExportMode.LINE;
 };
 export const saveImageExportMode = (mode: ImageExportMode) => {
-  localStorage.setItem(PRESET_ID, String(presetToNumber(mode)));
+  localStorage.setItem(IMAGE_EXPORT_MODE, String(modeToNumber(mode)));
 };
 
 export const loadAnimationImageOptions = (imageExportMode: ImageExportMode) => {

--- a/product/src/app/components/app/UserConfig.ts
+++ b/product/src/app/components/app/UserConfig.ts
@@ -4,8 +4,7 @@ import { PresetLine } from '../../../../common-src/preset/preset-line';
 import { PresetWeb } from '../../../../common-src/preset/preset-web';
 import {
   ImageExportMode,
-  numberToMode,
-  modeToNumber
+  numberToMode
 } from '../../../../common-src/type/ImageExportMode';
 import { LineValidationType } from '../../../../common-src/type/LineValidationType';
 

--- a/product/src/app/components/app/UserConfig.ts
+++ b/product/src/app/components/app/UserConfig.ts
@@ -29,7 +29,7 @@ export interface UserConfigsVer1 {
 export type UserConfigs = UserConfigsVer1;
 
 const USER_CONFIGS = 'user-configs'; // ユーザー設定
-const IMAGE_EXPORT_MODE = 'preset_id'; // 旧バージョンの設定
+const OLD_USER_CONFIGS = 'preset_id'; // 旧バージョンの設定
 const CURRENT_VERSION = 1;
 
 export const loadUserConfigs = (): UserConfigs => {
@@ -43,9 +43,9 @@ export const saveUserConfigs = (data: UserConfigs) => {
 // 旧バージョンのユーザー設定を新バージョンに移行する
 const migrationUserConfig = (): UserConfigs => {
   // 旧バージョンのユーザー設定を読み込む
-  const imagePresetMode = localStorage.getItem(IMAGE_EXPORT_MODE);
+  const imagePresetMode = localStorage.getItem(OLD_USER_CONFIGS);
   if (imagePresetMode) {
-    localStorage.removeItem(IMAGE_EXPORT_MODE); // 旧バージョンの設定を削除する
+    localStorage.removeItem(OLD_USER_CONFIGS); // 旧バージョンの設定を削除する
     const configs = migrationUserConfigFromVer0({
       imageExportNumber: Number(imagePresetMode)
     });

--- a/product/src/app/components/app/UserConfig.ts
+++ b/product/src/app/components/app/UserConfig.ts
@@ -1,3 +1,4 @@
+import { AnimationImageOptions } from '../../../../common-src/data/animation-image-option';
 import {
   ImageExportMode,
   numberToPreset,
@@ -5,10 +6,10 @@ import {
 } from '../../../../common-src/type/ImageExportMode';
 
 const PRESET_ID = 'preset_id';
-export const loadPresetConfig = (): ImageExportMode => {
+export const loadImageExportMode = (): ImageExportMode => {
   const presetNum = Number(localStorage.getItem(PRESET_ID));
   return numberToPreset(presetNum) ?? ImageExportMode.LINE;
 };
-export const savePresetConfig = (preset: ImageExportMode) => {
+export const saveImageExportMode = (preset: ImageExportMode) => {
   localStorage.setItem(PRESET_ID, String(presetToNumber(preset)));
 };

--- a/product/src/app/components/app/UserConfig.ts
+++ b/product/src/app/components/app/UserConfig.ts
@@ -14,11 +14,11 @@ export const saveImageExportMode = (mode: ImageExportMode) => {
   localStorage.setItem(PRESET_ID, String(presetToNumber(mode)));
 };
 
-export const loadAnimationImageOptions = (imageExportMode:ImageExportMode) => {
+export const loadAnimationImageOptions = (imageExportMode: ImageExportMode) => {
   const value = localStorage.getItem(imageExportMode);
   return value ? JSON.parse(value) : undefined;
 };
 
-export const saveAnimationImageOptions = (data:AnimationImageOptions) => {
+export const saveAnimationImageOptions = (data: AnimationImageOptions) => {
   localStorage.setItem(data.imageExportMode, JSON.stringify(data));
 };

--- a/product/src/app/components/app/UserConfig.ts
+++ b/product/src/app/components/app/UserConfig.ts
@@ -7,19 +7,19 @@ import {
 } from '../../../../common-src/type/ImageExportMode';
 import { LineValidationType } from '../../../../common-src/type/LineValidationType';
 
-type LineConfig = {
+interface LineConfig {
   animationOption: AnimationImageOptions;
   lineValidationType: LineValidationType;
 }
-type WebConfig = {
+interface WebConfig {
   animationOption: AnimationImageOptions;
 }
 
-export type UserConfigsVer0 = {
+export interface UserConfigsVer0 {
   imageExportNumber: number;
 }
 
-export type UserConfigsVer1 = {
+export interface UserConfigsVer1 {
   version: number;
   imageExportMode: ImageExportMode;
   lineConfig: LineConfig;
@@ -56,14 +56,16 @@ const migrationUserConfig = (): UserConfigs => {
 
   const loadedUserConfig = localStorage.getItem(USER_CONFIGS);
   // UserConfigsが存在しない場合はプリセットを返す
-  const userConfigs = loadedUserConfig ? JSON.parse(loadedUserConfig) : undefined;
+  const userConfigs = loadedUserConfig
+    ? JSON.parse(loadedUserConfig)
+    : undefined;
   if (userConfigs === undefined) {
     const configs = {
       version: CURRENT_VERSION,
       imageExportMode: ImageExportMode.LINE,
       lineConfig: PresetLine.getPresetVer1(),
-      webConfig: PresetWeb.getPresetVer1(),
-    }
+      webConfig: PresetWeb.getPresetVer1()
+    };
     // 新バージョンの設定を保存する
     saveUserConfigs(configs);
     return configs;
@@ -72,18 +74,21 @@ const migrationUserConfig = (): UserConfigs => {
   // ver1以降マイグレーションが必要な場合ここで対応する
 
   return userConfigs;
-}
+};
 
 /**
  * ver0設定から最新Ver設定に移行する
- * @param configVer0 
- * @returns 
+ * @param configVer0
+ * @returns
  */
-const migrationUserConfigFromVer0 = (configVer0: UserConfigsVer0): UserConfigs => {
+const migrationUserConfigFromVer0 = (
+  configVer0: UserConfigsVer0
+): UserConfigs => {
   return {
     version: CURRENT_VERSION,
-    imageExportMode: numberToMode(configVer0.imageExportNumber) ?? ImageExportMode.LINE,
+    imageExportMode:
+      numberToMode(configVer0.imageExportNumber) ?? ImageExportMode.LINE,
     lineConfig: PresetLine.getPresetVer1(),
-    webConfig: PresetWeb.getPresetVer1(),
-  }
-}
+    webConfig: PresetWeb.getPresetVer1()
+  };
+};

--- a/product/src/app/components/app/UserConfig.ts
+++ b/product/src/app/components/app/UserConfig.ts
@@ -1,14 +1,14 @@
 import {
-  PresetType,
+  ImageExportMode,
   numberToPreset,
   presetToNumber
-} from '../../../../common-src/type/PresetType';
+} from '../../../../common-src/type/ImageExportMode';
 
 const PRESET_ID = 'preset_id';
-export const loadPresetConfig = (): PresetType => {
+export const loadPresetConfig = (): ImageExportMode => {
   const presetNum = Number(localStorage.getItem(PRESET_ID));
-  return numberToPreset(presetNum) ?? PresetType.LINE;
+  return numberToPreset(presetNum) ?? ImageExportMode.LINE;
 };
-export const savePresetConfig = (preset: PresetType) => {
+export const savePresetConfig = (preset: ImageExportMode) => {
   localStorage.setItem(PRESET_ID, String(presetToNumber(preset)));
 };

--- a/product/src/app/components/app/UserConfig.ts
+++ b/product/src/app/components/app/UserConfig.ts
@@ -10,6 +10,15 @@ export const loadImageExportMode = (): ImageExportMode => {
   const presetNum = Number(localStorage.getItem(PRESET_ID));
   return numberToPreset(presetNum) ?? ImageExportMode.LINE;
 };
-export const saveImageExportMode = (preset: ImageExportMode) => {
-  localStorage.setItem(PRESET_ID, String(presetToNumber(preset)));
+export const saveImageExportMode = (mode: ImageExportMode) => {
+  localStorage.setItem(PRESET_ID, String(presetToNumber(mode)));
+};
+
+export const loadAnimationImageOptions = (imageExportMode:ImageExportMode) => {
+  const value = localStorage.getItem(imageExportMode);
+  return value ? JSON.parse(value) : undefined;
+};
+
+export const saveAnimationImageOptions = (data:AnimationImageOptions) => {
+  localStorage.setItem(data.imageExportMode, JSON.stringify(data));
 };

--- a/product/src/app/components/app/UserConfig.ts
+++ b/product/src/app/components/app/UserConfig.ts
@@ -1,4 +1,3 @@
-import { UserConfig } from 'vitest';
 import { AnimationImageOptions } from '../../../../common-src/data/animation-image-option';
 import { PresetLine } from '../../../../common-src/preset/preset-line';
 import { PresetWeb } from '../../../../common-src/preset/preset-web';

--- a/product/src/app/components/app/app.html
+++ b/product/src/app/components/app/app.html
@@ -34,6 +34,7 @@
       [animationOptionData]="animationOptionData"
       (showTooltipEvent)="changeTooltipShowing($event)"
       (buttonPos)="setShowingTooltipButtonPos($event)"
+      (changeAnimationOptionEvent)="handleChangeAnimationOption($event)"
     ></app-properties>
     <hr />
 

--- a/product/src/app/components/app/app.html
+++ b/product/src/app/components/app/app.html
@@ -42,9 +42,11 @@
       <!-- チェックルール -->
       <div class="checkRule mod-select-imageExportMode">
         <p class="mb-2">{{ localeData.RULE_title }}</p>
-        <select class="form-control mb-4" 
-        [formControl]="checkRule"
-        (ngModelChange)="handleChangeCheckRule()" >
+        <select
+          class="form-control mb-4"
+          [formControl]="checkRule"
+          (ngModelChange)="handleChangeCheckRule()"
+        >
           <option *ngFor="let checkRule of checkRuleList" [value]="checkRule">
             {{ checkRuleLabel[checkRule] }}
           </option>

--- a/product/src/app/components/app/app.html
+++ b/product/src/app/components/app/app.html
@@ -42,7 +42,9 @@
       <!-- チェックルール -->
       <div class="checkRule mod-select-imageExportMode">
         <p class="mb-2">{{ localeData.RULE_title }}</p>
-        <select class="form-control mb-4" [formControl]="checkRule">
+        <select class="form-control mb-4" 
+        [formControl]="checkRule"
+        (ngModelChange)="handleChangeCheckRule()" >
           <option *ngFor="let checkRule of checkRuleList" [value]="checkRule">
             {{ checkRuleLabel[checkRule] }}
           </option>

--- a/product/src/app/components/app/app.html
+++ b/product/src/app/components/app/app.html
@@ -11,17 +11,17 @@
           class="form-control"
           style="width: 100%"
           #optionSelecter
-          (change)="handlePresetChange(optionSelecter.value)"
+          (change)="handleImageExportChange(optionSelecter.value)"
         >
           <option
             [value]="ImageExportMode.LINE"
-            [selected]="presetMode === ImageExportMode.LINE"
+            [selected]="imageExportMode === ImageExportMode.LINE"
           >
             {{ localeData.PROP_useItemLine }}
           </option>
           <option
             [value]="ImageExportMode.WEB"
-            [selected]="presetMode === ImageExportMode.WEB"
+            [selected]="imageExportMode === ImageExportMode.WEB"
           >
             {{ localeData.PROP_useItemWeb }}
           </option>
@@ -37,9 +37,9 @@
     ></app-properties>
     <hr />
 
-    <div *ngIf="animationOptionData.preset === ImageExportMode.LINE">
+    <div *ngIf="animationOptionData.imageExportMode === ImageExportMode.LINE">
       <!-- チェックルール -->
-      <div class="checkRule mod-select-preset">
+      <div class="checkRule mod-select-imageExportMode">
         <p class="mb-2">{{ localeData.RULE_title }}</p>
         <select class="form-control mb-4" [formControl]="checkRule">
           <option *ngFor="let checkRule of checkRuleList" [value]="checkRule">

--- a/product/src/app/components/app/app.html
+++ b/product/src/app/components/app/app.html
@@ -14,14 +14,14 @@
           (change)="handlePresetChange(optionSelecter.value)"
         >
           <option
-            [value]="PresetType.LINE"
-            [selected]="presetMode === PresetType.LINE"
+            [value]="ImageExportMode.LINE"
+            [selected]="presetMode === ImageExportMode.LINE"
           >
             {{ localeData.PROP_useItemLine }}
           </option>
           <option
-            [value]="PresetType.WEB"
-            [selected]="presetMode === PresetType.WEB"
+            [value]="ImageExportMode.WEB"
+            [selected]="presetMode === ImageExportMode.WEB"
           >
             {{ localeData.PROP_useItemWeb }}
           </option>
@@ -37,7 +37,7 @@
     ></app-properties>
     <hr />
 
-    <div *ngIf="animationOptionData.preset === PresetType.LINE">
+    <div *ngIf="animationOptionData.preset === ImageExportMode.LINE">
       <!-- チェックルール -->
       <div class="checkRule mod-select-preset">
         <p class="mb-2">{{ localeData.RULE_title }}</p>

--- a/product/src/app/components/app/app.ts
+++ b/product/src/app/components/app/app.ts
@@ -9,7 +9,7 @@ import {
 import { AppConfig } from '../../../../common-src/config/app-config';
 import { DomSanitizer } from '@angular/platform-browser';
 import IpcService from '../../process/ipc.service';
-import { PresetType } from '../../../../common-src/type/PresetType';
+import { ImageExportMode } from '../../../../common-src/type/ImageExportMode';
 import { PresetLine } from '../../../../common-src/preset/preset-line';
 import { PresetWeb } from '../../../../common-src/preset/preset-web';
 import { AnimationImageOptions } from '../../../../common-src/data/animation-image-option';
@@ -46,12 +46,14 @@ export class AppComponent implements OnInit, AfterViewInit {
   private apngFileSizeError = false;
   readonly AppConfig = AppConfig;
 
+  // クラス名を.htmlから使用できるようにする
+  ImageExportMode = ImageExportMode;
+
   isImageSelected = false;
   isUiLocked = false;
   _isDragover = false;
-  presetMode = PresetType.LINE;
+  presetMode = ImageExportMode.LINE;
   items: ImageData[] = [];
-  PresetType = PresetType;
   localeData = localeData;
   validationErrorsMessage = [''];
 
@@ -123,19 +125,19 @@ export class AppComponent implements OnInit, AfterViewInit {
 
   handlePresetChange(presetMode: string) {
     const preset =
-      presetMode === PresetType.WEB ? PresetType.WEB : PresetType.LINE;
+      presetMode === ImageExportMode.WEB ? ImageExportMode.WEB : ImageExportMode.LINE;
     savePresetConfig(preset);
     this.presetMode = preset;
 
     this.changePreset(this.presetMode);
   }
 
-  changePreset(presetMode: PresetType) {
+  changePreset(presetMode: ImageExportMode) {
     switch (presetMode) {
-      case PresetType.LINE:
+      case ImageExportMode.LINE:
         PresetLine.setPreset(this.animationOptionData);
         break;
-      case PresetType.WEB:
+      case ImageExportMode.WEB:
         PresetWeb.setPreset(this.animationOptionData);
         break;
     }

--- a/product/src/app/components/app/app.ts
+++ b/product/src/app/components/app/app.ts
@@ -15,7 +15,7 @@ import { PresetWeb } from '../../../../common-src/preset/preset-web';
 import { AnimationImageOptions } from '../../../../common-src/data/animation-image-option';
 import { ImageData } from '../../../../common-src/data/image-data';
 import { checkImagePxSizeMatched } from './checkImagePxSizeMatched';
-import { loadImageExportMode, saveImageExportMode } from './UserConfig';
+import { loadImageExportMode, saveImageExportMode, loadAnimationImageOptions, saveAnimationImageOptions } from './UserConfig';
 import { localeData } from 'app/i18n/locale-manager';
 import { LineValidationType } from '../../../../common-src/type/LineValidationType';
 import { checkRuleList } from '../../../../common-src/checkRule/checkRule';
@@ -82,7 +82,7 @@ export class AppComponent implements OnInit, AfterViewInit {
   @ViewChild('optionSelecter', { static: true })
   optionSelecterComponent?: ElementRef;
 
-  constructor(sanitizer: DomSanitizer, private ipcService: IpcService) {}
+  constructor(sanitizer: DomSanitizer, private ipcService: IpcService) { }
 
   ngOnInit() {
     this.animationOptionData = new AnimationImageOptions();
@@ -125,7 +125,7 @@ export class AppComponent implements OnInit, AfterViewInit {
 
   handleImageExportChange(imageExportMode: string) {
     const imageExport =
-    imageExportMode === ImageExportMode.WEB ? ImageExportMode.WEB : ImageExportMode.LINE;
+      imageExportMode === ImageExportMode.WEB ? ImageExportMode.WEB : ImageExportMode.LINE;
     saveImageExportMode(imageExport);
     this.imageExportMode = imageExport;
 
@@ -133,14 +133,24 @@ export class AppComponent implements OnInit, AfterViewInit {
   }
 
   changeImageExportMode(imageExportMode: ImageExportMode) {
+    let loadedOptions = loadAnimationImageOptions(imageExportMode);
+    let presetData;
     switch (imageExportMode) {
       case ImageExportMode.LINE:
-        PresetLine.setPreset(this.animationOptionData);
+        presetData = PresetLine.getPreset();
         break;
       case ImageExportMode.WEB:
-        PresetWeb.setPreset(this.animationOptionData);
+        presetData = PresetWeb.getPreset();
         break;
+      default:
+        presetData = PresetLine.getPreset();
     }
+
+    if (loadedOptions === undefined || loadedOptions === null) {
+      this.animationOptionData = presetData;
+      return;
+    }
+    this.animationOptionData = { ...presetData, ...loadedOptions };
   }
 
   async generateAnimImage(): Promise<void> {
@@ -311,5 +321,9 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.validationErrorsMessage = (Object.values(errors) as ValidationResult[])
       .filter((value) => value !== undefined)
       .map((value) => value?.message ?? '');
+  }
+
+  handleChangeAnimationOption(animationOptionData: AnimationImageOptions) {
+    saveAnimationImageOptions(animationOptionData);
   }
 }

--- a/product/src/app/components/app/app.ts
+++ b/product/src/app/components/app/app.ts
@@ -15,7 +15,7 @@ import { PresetWeb } from '../../../../common-src/preset/preset-web';
 import { AnimationImageOptions } from '../../../../common-src/data/animation-image-option';
 import { ImageData } from '../../../../common-src/data/image-data';
 import { checkImagePxSizeMatched } from './checkImagePxSizeMatched';
-import { loadPresetConfig, savePresetConfig } from './UserConfig';
+import { loadImageExportMode, saveImageExportMode } from './UserConfig';
 import { localeData } from 'app/i18n/locale-manager';
 import { LineValidationType } from '../../../../common-src/type/LineValidationType';
 import { checkRuleList } from '../../../../common-src/checkRule/checkRule';
@@ -90,8 +90,8 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.isImageSelected = false;
 
     // 初回プリセットの設定
-    this.imageExportMode = loadPresetConfig();
-    this.changePreset(this.imageExportMode);
+    this.imageExportMode = loadImageExportMode();
+    this.changeImageExportMode(this.imageExportMode);
   }
 
   ngAfterViewInit() {
@@ -123,16 +123,16 @@ export class AppComponent implements OnInit, AfterViewInit {
     event.preventDefault();
   }
 
-  handlePresetChange(imageExportMode: string) {
+  handleImageExportChange(imageExportMode: string) {
     const imageExport =
     imageExportMode === ImageExportMode.WEB ? ImageExportMode.WEB : ImageExportMode.LINE;
-    savePresetConfig(imageExport);
+    saveImageExportMode(imageExport);
     this.imageExportMode = imageExport;
 
-    this.changePreset(this.imageExportMode);
+    this.changeImageExportMode(this.imageExportMode);
   }
 
-  changePreset(imageExportMode: ImageExportMode) {
+  changeImageExportMode(imageExportMode: ImageExportMode) {
     switch (imageExportMode) {
       case ImageExportMode.LINE:
         PresetLine.setPreset(this.animationOptionData);

--- a/product/src/app/components/app/app.ts
+++ b/product/src/app/components/app/app.ts
@@ -15,7 +15,12 @@ import { PresetWeb } from '../../../../common-src/preset/preset-web';
 import { AnimationImageOptions } from '../../../../common-src/data/animation-image-option';
 import { ImageData } from '../../../../common-src/data/image-data';
 import { checkImagePxSizeMatched } from './checkImagePxSizeMatched';
-import { loadImageExportMode, saveImageExportMode, loadAnimationImageOptions, saveAnimationImageOptions } from './UserConfig';
+import {
+  loadImageExportMode,
+  saveImageExportMode,
+  loadAnimationImageOptions,
+  saveAnimationImageOptions
+} from './UserConfig';
 import { localeData } from 'app/i18n/locale-manager';
 import { LineValidationType } from '../../../../common-src/type/LineValidationType';
 import { checkRuleList } from '../../../../common-src/checkRule/checkRule';
@@ -82,7 +87,7 @@ export class AppComponent implements OnInit, AfterViewInit {
   @ViewChild('optionSelecter', { static: true })
   optionSelecterComponent?: ElementRef;
 
-  constructor(sanitizer: DomSanitizer, private ipcService: IpcService) { }
+  constructor(sanitizer: DomSanitizer, private ipcService: IpcService) {}
 
   ngOnInit() {
     this.animationOptionData = new AnimationImageOptions();
@@ -125,7 +130,9 @@ export class AppComponent implements OnInit, AfterViewInit {
 
   handleImageExportChange(imageExportMode: string) {
     const imageExport =
-      imageExportMode === ImageExportMode.WEB ? ImageExportMode.WEB : ImageExportMode.LINE;
+      imageExportMode === ImageExportMode.WEB
+        ? ImageExportMode.WEB
+        : ImageExportMode.LINE;
     saveImageExportMode(imageExport);
     this.imageExportMode = imageExport;
 

--- a/product/src/app/components/app/app.ts
+++ b/product/src/app/components/app/app.ts
@@ -52,7 +52,7 @@ export class AppComponent implements OnInit, AfterViewInit {
   isImageSelected = false;
   isUiLocked = false;
   _isDragover = false;
-  presetMode = ImageExportMode.LINE;
+  imageExportMode = ImageExportMode.LINE;
   items: ImageData[] = [];
   localeData = localeData;
   validationErrorsMessage = [''];
@@ -90,8 +90,8 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.isImageSelected = false;
 
     // 初回プリセットの設定
-    this.presetMode = loadPresetConfig();
-    this.changePreset(this.presetMode);
+    this.imageExportMode = loadPresetConfig();
+    this.changePreset(this.imageExportMode);
   }
 
   ngAfterViewInit() {
@@ -123,17 +123,17 @@ export class AppComponent implements OnInit, AfterViewInit {
     event.preventDefault();
   }
 
-  handlePresetChange(presetMode: string) {
-    const preset =
-      presetMode === ImageExportMode.WEB ? ImageExportMode.WEB : ImageExportMode.LINE;
-    savePresetConfig(preset);
-    this.presetMode = preset;
+  handlePresetChange(imageExportMode: string) {
+    const imageExport =
+    imageExportMode === ImageExportMode.WEB ? ImageExportMode.WEB : ImageExportMode.LINE;
+    savePresetConfig(imageExport);
+    this.imageExportMode = imageExport;
 
-    this.changePreset(this.presetMode);
+    this.changePreset(this.imageExportMode);
   }
 
-  changePreset(presetMode: ImageExportMode) {
-    switch (presetMode) {
+  changePreset(imageExportMode: ImageExportMode) {
+    switch (imageExportMode) {
       case ImageExportMode.LINE:
         PresetLine.setPreset(this.animationOptionData);
         break;

--- a/product/src/app/components/app/app.ts
+++ b/product/src/app/components/app/app.ts
@@ -15,11 +15,7 @@ import { PresetWeb } from '../../../../common-src/preset/preset-web';
 import { AnimationImageOptions } from '../../../../common-src/data/animation-image-option';
 import { ImageData } from '../../../../common-src/data/image-data';
 import { checkImagePxSizeMatched } from './checkImagePxSizeMatched';
-import {
-  loadUserConfigs,
-  saveUserConfigs,
-  UserConfigs
-} from './UserConfig';
+import { loadUserConfigs, saveUserConfigs, UserConfigs } from './UserConfig';
 import { localeData } from 'app/i18n/locale-manager';
 import { LineValidationType } from '../../../../common-src/type/LineValidationType';
 import { checkRuleList } from '../../../../common-src/checkRule/checkRule';
@@ -87,7 +83,7 @@ export class AppComponent implements OnInit, AfterViewInit {
   @ViewChild('optionSelecter', { static: true })
   optionSelecterComponent?: ElementRef;
 
-  constructor(sanitizer: DomSanitizer, private ipcService: IpcService) { }
+  constructor(sanitizer: DomSanitizer, private ipcService: IpcService) {}
 
   ngOnInit() {
     this.animationOptionData = new AnimationImageOptions();
@@ -98,7 +94,9 @@ export class AppComponent implements OnInit, AfterViewInit {
 
     // 設定の読み込み
     this.imageExportMode = this.userConfigs.imageExportMode;
-    this.checkRule.setValue(this.userConfigs.lineConfig.lineValidationType, { emitEvent: false });
+    this.checkRule.setValue(this.userConfigs.lineConfig.lineValidationType, {
+      emitEvent: false
+    });
 
     this.changeImageExportMode(this.imageExportMode);
   }
@@ -137,7 +135,7 @@ export class AppComponent implements OnInit, AfterViewInit {
       imageExportMode === ImageExportMode.WEB
         ? ImageExportMode.WEB
         : ImageExportMode.LINE;
-        
+
     this.imageExportMode = imageExport;
 
     this.changeImageExportMode(this.imageExportMode);
@@ -149,7 +147,6 @@ export class AppComponent implements OnInit, AfterViewInit {
    * @param imageExportMode
    */
   changeImageExportMode(imageExportMode: ImageExportMode) {
-
     if (!this.userConfigs) {
       // 想定しない挙動なのでエラー発生でOK
       throw new Error('userConfigs is null');
@@ -158,7 +155,10 @@ export class AppComponent implements OnInit, AfterViewInit {
     switch (imageExportMode) {
       case ImageExportMode.LINE:
         this.animationOptionData = this.userConfigs.lineConfig.animationOption;
-        this.checkRule.setValue(this.userConfigs.lineConfig.lineValidationType, { emitEvent: false });
+        this.checkRule.setValue(
+          this.userConfigs.lineConfig.lineValidationType,
+          { emitEvent: false }
+        );
         break;
       case ImageExportMode.WEB:
         this.animationOptionData = this.userConfigs.webConfig.animationOption;
@@ -166,7 +166,6 @@ export class AppComponent implements OnInit, AfterViewInit {
     }
     this.userConfigs.imageExportMode = imageExportMode;
   }
-
 
   async generateAnimImage(): Promise<void> {
     // 	画像が選択されていないので保存しない。
@@ -338,13 +337,12 @@ export class AppComponent implements OnInit, AfterViewInit {
       .map((value) => value?.message ?? '');
   }
 
-
   handleChangeAnimationOption(animationOptionData: AnimationImageOptions) {
     this.saveConfig();
   }
 
   handleChangeCheckRule(): void {
-    this.saveConfig()
+    this.saveConfig();
   }
 
   saveConfig() {
@@ -354,10 +352,15 @@ export class AppComponent implements OnInit, AfterViewInit {
 
     switch (this.animationOptionData.imageExportMode) {
       case ImageExportMode.LINE:
-        this.userConfigs.lineConfig = { animationOption: this.animationOptionData, lineValidationType: this.checkRule.value };
+        this.userConfigs.lineConfig = {
+          animationOption: this.animationOptionData,
+          lineValidationType: this.checkRule.value
+        };
         break;
       case ImageExportMode.WEB:
-        this.userConfigs.webConfig = { animationOption: this.animationOptionData };
+        this.userConfigs.webConfig = {
+          animationOption: this.animationOptionData
+        };
         break;
     }
 

--- a/product/src/app/components/app/app.ts
+++ b/product/src/app/components/app/app.ts
@@ -94,7 +94,7 @@ export class AppComponent implements OnInit, AfterViewInit {
 
     this.isImageSelected = false;
 
-    // 初回プリセットの設定
+    // 設定の読み込み
     this.imageExportMode = loadImageExportMode();
     this.changeImageExportMode(this.imageExportMode);
   }
@@ -139,24 +139,28 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.changeImageExportMode(this.imageExportMode);
   }
 
+  /**
+   * 画像出力方法を変更
+   * @param imageExportMode
+   */
   changeImageExportMode(imageExportMode: ImageExportMode) {
     let loadedOptions = loadAnimationImageOptions(imageExportMode);
     let presetData;
     switch (imageExportMode) {
-      case ImageExportMode.LINE:
-        presetData = PresetLine.getPreset();
-        break;
       case ImageExportMode.WEB:
         presetData = PresetWeb.getPreset();
         break;
+      case ImageExportMode.LINE:
       default:
         presetData = PresetLine.getPreset();
     }
 
+    // データがなければプリセットを使用する
     if (loadedOptions === undefined || loadedOptions === null) {
       this.animationOptionData = presetData;
       return;
     }
+    // 保存されているオプションを優先で、設定がなければプリセットを使用する
     this.animationOptionData = { ...presetData, ...loadedOptions };
   }
 

--- a/product/src/app/components/properties/properties.html
+++ b/product/src/app/components/properties/properties.html
@@ -33,7 +33,7 @@
             data-toggle="tooltip"
             data-placement="right"
             title="{{ localeData.PROP_tabAnimFpsTooltip }}"
-            *ngIf="animationOptionData.preset === PresetType.LINE"
+            *ngIf="animationOptionData.preset === ImageExportMode.LINE"
             (blur)="avoidBlankFpsNum()"
           />
           <input
@@ -42,7 +42,7 @@
             [(ngModel)]="animationOptionData.fps"
             min="1"
             max="60"
-            *ngIf="animationOptionData.preset === PresetType.WEB"
+            *ngIf="animationOptionData.preset === ImageExportMode.WEB"
             (blur)="avoidBlankFpsNum()"
           />
         </div>
@@ -50,7 +50,7 @@
 
       <div
         class="form-group row"
-        *ngIf="animationOptionData.preset === PresetType.WEB"
+        *ngIf="animationOptionData.preset === ImageExportMode.WEB"
       >
         <label class="col-sm-6 form-control-label">{{
           localeData.PROP_tabAnimLoop
@@ -79,7 +79,7 @@
             data-toggle="tooltip"
             data-placement="right"
             title="{{ localeData.PROP_tabAnimLoopTooltip }}"
-            *ngIf="animationOptionData.preset === PresetType.LINE"
+            *ngIf="animationOptionData.preset === ImageExportMode.LINE"
             (blur)="avoidBlankLoopNum()"
           />
           <input
@@ -87,7 +87,7 @@
             class="form-control"
             [(ngModel)]="animationOptionData.loop"
             min="1"
-            *ngIf="animationOptionData.preset === PresetType.WEB"
+            *ngIf="animationOptionData.preset === ImageExportMode.WEB"
             (blur)="avoidBlankLoopNum()"
           />
         </div>
@@ -98,7 +98,7 @@
       <!-- APNGファイル出力 -->
       <div
         class="checkbox"
-        *ngIf="animationOptionData.preset === PresetType.WEB"
+        *ngIf="animationOptionData.preset === ImageExportMode.WEB"
       >
         <label
           data-toggle="tooltip"
@@ -213,7 +213,7 @@
         </div>
       </div>
 
-      <div *ngIf="animationOptionData.preset === PresetType.WEB">
+      <div *ngIf="animationOptionData.preset === ImageExportMode.WEB">
         <!-- WebPファイル出力 -->
         <div class="checkbox">
           <label

--- a/product/src/app/components/properties/properties.html
+++ b/product/src/app/components/properties/properties.html
@@ -40,6 +40,7 @@
             type="number"
             class="form-control"
             [(ngModel)]="animationOptionData.fps"
+            (ngModelChange)="changeAnimationOption()"
             min="1"
             max="60"
             *ngIf="animationOptionData.imageExportMode === ImageExportMode.WEB"
@@ -58,7 +59,9 @@
         <div class="col-sm-6">
           <div class="checkbox">
             <label>
-              <input type="checkbox" [(ngModel)]="animationOptionData.noLoop" />
+              <input type="checkbox" 
+              [(ngModel)]="animationOptionData.noLoop"
+              (ngModelChange)="changeAnimationOption()" />
               {{ localeData.PROP_tabAnimLoopInitiny }}
             </label>
           </div>
@@ -74,6 +77,7 @@
             type="number"
             class="form-control"
             [(ngModel)]="animationOptionData.loop"
+            (ngModelChange)="changeAnimationOption()" 
             min="1"
             max="4"
             data-toggle="tooltip"
@@ -86,6 +90,7 @@
             type="number"
             class="form-control"
             [(ngModel)]="animationOptionData.loop"
+            (ngModelChange)="changeAnimationOption()" 
             min="1"
             *ngIf="animationOptionData.imageExportMode === ImageExportMode.WEB"
             (blur)="avoidBlankLoopNum()"
@@ -108,6 +113,7 @@
           <input
             type="checkbox"
             [(ngModel)]="animationOptionData.enabledExportApng"
+            (ngModelChange)="changeAnimationOption()" 
           />
           {{ localeData.PROP_tabQualityHApng }}
         </label>
@@ -129,6 +135,7 @@
               type="checkbox"
               class="mr-1"
               [(ngModel)]="animationOptionData.enabledPngCompress"
+              (ngModelChange)="changeAnimationOption()" 
             />
             {{ localeData.PROP_tabQualityApngOpt }}
           </label>
@@ -151,7 +158,7 @@
               type="radio"
               id="radio-zopfli"
               data-html="true"
-              (click)="animationOptionData.compression = CompressionType.zopfli"
+              (click)="animationOptionData.compression = CompressionType.zopfli; changeAnimationOption()"
               [checked]="
                 animationOptionData.compression === CompressionType.zopfli
               "
@@ -173,7 +180,7 @@
               name="radio-stacked"
               type="radio"
               id="radio-7zip"
-              (click)="animationOptionData.compression = CompressionType.zip7"
+              (click)="animationOptionData.compression = CompressionType.zip7; changeAnimationOption()"
               [checked]="
                 animationOptionData.compression === CompressionType.zip7
               "
@@ -195,7 +202,7 @@
               name="radio-stacked"
               type="radio"
               id="radio-zlib"
-              (click)="animationOptionData.compression = CompressionType.zlib"
+              (click)="animationOptionData.compression = CompressionType.zlib; changeAnimationOption()"
               [checked]="
                 animationOptionData.compression === CompressionType.zlib
               "
@@ -224,6 +231,7 @@
             <input
               type="checkbox"
               [(ngModel)]="animationOptionData.enabledExportWebp"
+              (ngModelChange)="changeAnimationOption()" 
             />
             {{ localeData.PROP_tabQualityHWebp }}
           </label>
@@ -243,6 +251,7 @@
               <input
                 type="checkbox"
                 [(ngModel)]="animationOptionData.enabledWebpCompress"
+                (ngModelChange)="changeAnimationOption()" 
               />
               {{ localeData.PROP_tabQualityApngOpt }}
             </label>
@@ -259,6 +268,7 @@
             <input
               type="checkbox"
               [(ngModel)]="animationOptionData.enabledExportHtml"
+              (ngModelChange)="changeAnimationOption()" 
             />
             {{ localeData.PROP_tabQualityHHtml }}
           </label>

--- a/product/src/app/components/properties/properties.html
+++ b/product/src/app/components/properties/properties.html
@@ -33,7 +33,7 @@
             data-toggle="tooltip"
             data-placement="right"
             title="{{ localeData.PROP_tabAnimFpsTooltip }}"
-            *ngIf="animationOptionData.preset === ImageExportMode.LINE"
+            *ngIf="animationOptionData.imageExportMode === ImageExportMode.LINE"
             (blur)="avoidBlankFpsNum()"
           />
           <input
@@ -42,7 +42,7 @@
             [(ngModel)]="animationOptionData.fps"
             min="1"
             max="60"
-            *ngIf="animationOptionData.preset === ImageExportMode.WEB"
+            *ngIf="animationOptionData.imageExportMode === ImageExportMode.WEB"
             (blur)="avoidBlankFpsNum()"
           />
         </div>
@@ -50,7 +50,7 @@
 
       <div
         class="form-group row"
-        *ngIf="animationOptionData.preset === ImageExportMode.WEB"
+        *ngIf="animationOptionData.imageExportMode === ImageExportMode.WEB"
       >
         <label class="col-sm-6 form-control-label">{{
           localeData.PROP_tabAnimLoop
@@ -79,7 +79,7 @@
             data-toggle="tooltip"
             data-placement="right"
             title="{{ localeData.PROP_tabAnimLoopTooltip }}"
-            *ngIf="animationOptionData.preset === ImageExportMode.LINE"
+            *ngIf="animationOptionData.imageExportMode === ImageExportMode.LINE"
             (blur)="avoidBlankLoopNum()"
           />
           <input
@@ -87,7 +87,7 @@
             class="form-control"
             [(ngModel)]="animationOptionData.loop"
             min="1"
-            *ngIf="animationOptionData.preset === ImageExportMode.WEB"
+            *ngIf="animationOptionData.imageExportMode === ImageExportMode.WEB"
             (blur)="avoidBlankLoopNum()"
           />
         </div>
@@ -98,7 +98,7 @@
       <!-- APNGファイル出力 -->
       <div
         class="checkbox"
-        *ngIf="animationOptionData.preset === ImageExportMode.WEB"
+        *ngIf="animationOptionData.imageExportMode === ImageExportMode.WEB"
       >
         <label
           data-toggle="tooltip"
@@ -213,7 +213,7 @@
         </div>
       </div>
 
-      <div *ngIf="animationOptionData.preset === ImageExportMode.WEB">
+      <div *ngIf="animationOptionData.imageExportMode === ImageExportMode.WEB">
         <!-- WebPファイル出力 -->
         <div class="checkbox">
           <label

--- a/product/src/app/components/properties/properties.html
+++ b/product/src/app/components/properties/properties.html
@@ -59,9 +59,11 @@
         <div class="col-sm-6">
           <div class="checkbox">
             <label>
-              <input type="checkbox" 
-              [(ngModel)]="animationOptionData.noLoop"
-              (ngModelChange)="changeAnimationOption()" />
+              <input
+                type="checkbox"
+                [(ngModel)]="animationOptionData.noLoop"
+                (ngModelChange)="changeAnimationOption()"
+              />
               {{ localeData.PROP_tabAnimLoopInitiny }}
             </label>
           </div>
@@ -77,7 +79,7 @@
             type="number"
             class="form-control"
             [(ngModel)]="animationOptionData.loop"
-            (ngModelChange)="changeAnimationOption()" 
+            (ngModelChange)="changeAnimationOption()"
             min="1"
             max="4"
             data-toggle="tooltip"
@@ -90,7 +92,7 @@
             type="number"
             class="form-control"
             [(ngModel)]="animationOptionData.loop"
-            (ngModelChange)="changeAnimationOption()" 
+            (ngModelChange)="changeAnimationOption()"
             min="1"
             *ngIf="animationOptionData.imageExportMode === ImageExportMode.WEB"
             (blur)="avoidBlankLoopNum()"
@@ -113,7 +115,7 @@
           <input
             type="checkbox"
             [(ngModel)]="animationOptionData.enabledExportApng"
-            (ngModelChange)="changeAnimationOption()" 
+            (ngModelChange)="changeAnimationOption()"
           />
           {{ localeData.PROP_tabQualityHApng }}
         </label>
@@ -135,7 +137,7 @@
               type="checkbox"
               class="mr-1"
               [(ngModel)]="animationOptionData.enabledPngCompress"
-              (ngModelChange)="changeAnimationOption()" 
+              (ngModelChange)="changeAnimationOption()"
             />
             {{ localeData.PROP_tabQualityApngOpt }}
           </label>
@@ -158,7 +160,10 @@
               type="radio"
               id="radio-zopfli"
               data-html="true"
-              (click)="animationOptionData.compression = CompressionType.zopfli; changeAnimationOption()"
+              (click)="
+                animationOptionData.compression = CompressionType.zopfli;
+                changeAnimationOption()
+              "
               [checked]="
                 animationOptionData.compression === CompressionType.zopfli
               "
@@ -180,7 +185,10 @@
               name="radio-stacked"
               type="radio"
               id="radio-7zip"
-              (click)="animationOptionData.compression = CompressionType.zip7; changeAnimationOption()"
+              (click)="
+                animationOptionData.compression = CompressionType.zip7;
+                changeAnimationOption()
+              "
               [checked]="
                 animationOptionData.compression === CompressionType.zip7
               "
@@ -202,7 +210,10 @@
               name="radio-stacked"
               type="radio"
               id="radio-zlib"
-              (click)="animationOptionData.compression = CompressionType.zlib; changeAnimationOption()"
+              (click)="
+                animationOptionData.compression = CompressionType.zlib;
+                changeAnimationOption()
+              "
               [checked]="
                 animationOptionData.compression === CompressionType.zlib
               "
@@ -231,7 +242,7 @@
             <input
               type="checkbox"
               [(ngModel)]="animationOptionData.enabledExportWebp"
-              (ngModelChange)="changeAnimationOption()" 
+              (ngModelChange)="changeAnimationOption()"
             />
             {{ localeData.PROP_tabQualityHWebp }}
           </label>
@@ -251,7 +262,7 @@
               <input
                 type="checkbox"
                 [(ngModel)]="animationOptionData.enabledWebpCompress"
-                (ngModelChange)="changeAnimationOption()" 
+                (ngModelChange)="changeAnimationOption()"
               />
               {{ localeData.PROP_tabQualityApngOpt }}
             </label>
@@ -268,7 +279,7 @@
             <input
               type="checkbox"
               [(ngModel)]="animationOptionData.enabledExportHtml"
-              (ngModelChange)="changeAnimationOption()" 
+              (ngModelChange)="changeAnimationOption()"
             />
             {{ localeData.PROP_tabQualityHHtml }}
           </label>

--- a/product/src/app/components/properties/properties.ts
+++ b/product/src/app/components/properties/properties.ts
@@ -30,6 +30,9 @@ export class PropertiesComponent {
   @Output()
   showTooltipEvent = new EventEmitter<Tooltip>();
 
+  @Output()
+  changeAnimationOptionEvent = new EventEmitter<AnimationImageOptions>();
+
   @ViewChild('tooltipElement')
   tooltipElement: ElementRef | undefined;
 
@@ -61,5 +64,9 @@ export class PropertiesComponent {
       x: this.tooltipElement?.nativeElement.getBoundingClientRect().x,
       y: this.tooltipElement?.nativeElement.getBoundingClientRect().y
     });
+  }
+  
+  changeAnimationOption() {
+    this.changeAnimationOptionEvent.emit(this.animationOptionData);
   }
 }

--- a/product/src/app/components/properties/properties.ts
+++ b/product/src/app/components/properties/properties.ts
@@ -9,7 +9,7 @@ import {
 import { localeData } from 'app/i18n/locale-manager';
 import { AnimationImageOptions } from '../../../../common-src/data/animation-image-option';
 import { CompressionType } from '../../../../common-src/type/CompressionType';
-import { PresetType } from '../../../../common-src/type/PresetType';
+import { ImageExportMode } from '../../../../common-src/type/ImageExportMode';
 import { Tooltip } from '../../../../common-src/type/TooltipType';
 
 @Component({
@@ -33,8 +33,10 @@ export class PropertiesComponent {
   @ViewChild('tooltipElement')
   tooltipElement: ElementRef | undefined;
 
-  PresetType = PresetType;
+  // クラス名を.html内から使用できるようにする
+  ImageExportMode = ImageExportMode;
   CompressionType = CompressionType;
+  
   localeData = localeData;
 
   constructor() {}

--- a/product/src/app/components/properties/properties.ts
+++ b/product/src/app/components/properties/properties.ts
@@ -39,7 +39,7 @@ export class PropertiesComponent {
   // クラス名を.html内から使用できるようにする
   ImageExportMode = ImageExportMode;
   CompressionType = CompressionType;
-  
+
   localeData = localeData;
 
   constructor() {}
@@ -65,7 +65,7 @@ export class PropertiesComponent {
       y: this.tooltipElement?.nativeElement.getBoundingClientRect().y
     });
   }
-  
+
   changeAnimationOption() {
     this.changeAnimationOptionEvent.emit(this.animationOptionData);
   }


### PR DESCRIPTION
## 対応意図
起動や用途が切り替えられるたびに画像出力の設定がリセットされていたため、アプリ再起動時に毎回画像出力の設定する必要があり不便でした

## 修正内容
画像出力の設定をセーブ・ロードするように修正しました

- プリセット(初期設定)というクラス・関数・変数名周りのリネーム 
- ウェブページ用・LINEアニメーション用それぞれのAnimationImageOptionを設定値の変更タイミングでlocalStorageに保存

## 期待する結果
- アプリを再起動のタイミングでLINE/WEBそれぞれで変更した設定が保存されていること
- 用途のLINE/WEBを切り替えた時に設定が混ざらないこと