### PR TITLE
設定データに画像のサイズが含まれてしまい、別の画像を読み込み用途を切り替えた時に画像サイズが異なってしまう不具合の修正

### DIFF
--- a/product/common-src/data/animation-image-option.ts
+++ b/product/common-src/data/animation-image-option.ts
@@ -17,11 +17,4 @@ export class AnimationImageOptions {
   enabledExportApng = false;
   enabledExportWebp = false;
   enabledExportHtml = false;
-
-  /** 画像の情報です。 */
-  imageInfo = {
-    width: 0,
-    height: 0,
-    length: 0
-  };
 }

--- a/product/common-src/data/image-info.ts
+++ b/product/common-src/data/image-info.ts
@@ -1,0 +1,6 @@
+export class ImageInfo {
+  /** 画像の情報です。 */
+  public width:number = 0;
+  public height:number = 0;
+  public length:number = 0;
+}

--- a/product/common-src/ipc-id.ts
+++ b/product/common-src/ipc-id.ts
@@ -2,6 +2,7 @@ import { IpcMainInvokeEvent } from 'electron';
 import { AnimationImageOptions } from './data/animation-image-option';
 import { ImageData } from './data/image-data';
 import { LineValidationType } from './type/LineValidationType';
+import { ImageInfo } from './data/image-info';
 
 // プロセス間通信のchannel名の定数定義です
 export const IpcId = {
@@ -29,6 +30,7 @@ interface IpcInvokeFuncs {
   ) => Promise<void>;
   [IpcId.EXEC_IMAGE_EXPORT_PROCESS]: (
     version: string,
+    imageInfo: ImageInfo,
     itemList: ImageData[],
     animationOptionData: AnimationImageOptions,
     validationType: LineValidationType,

--- a/product/common-src/validators/validateLineStamp.test.ts
+++ b/product/common-src/validators/validateLineStamp.test.ts
@@ -14,9 +14,6 @@ describe('test linestamp validation', () => {
     option.imageExportMode = ImageExportMode.LINE;
     option.fps = 5;
     option.loop = 1;
-    imageInfo.width = 240;
-    imageInfo.height = 240;
-    imageInfo.length = 5;
     const result = validateLineStamp(LineValidationType.ANIMATION_MAIN, imageInfo, option);
     const isValid = Object.values(result).every((r) => r === undefined);
     if (!isValid) {

--- a/product/common-src/validators/validateLineStamp.test.ts
+++ b/product/common-src/validators/validateLineStamp.test.ts
@@ -9,14 +9,15 @@ describe('test linestamp validation', () => {
   // アニメーションスタンプ メイン
 
   test('should pass for min animation main', () => {
+    const imageInfo = {width: 240, height: 240, length: 5};
     const option: AnimationImageOptions = new AnimationImageOptions();
     option.imageExportMode = ImageExportMode.LINE;
     option.fps = 5;
     option.loop = 1;
-    option.imageInfo.width = 240;
-    option.imageInfo.height = 240;
-    option.imageInfo.length = 5;
-    const result = validateLineStamp(LineValidationType.ANIMATION_MAIN, option);
+    imageInfo.width = 240;
+    imageInfo.height = 240;
+    imageInfo.length = 5;
+    const result = validateLineStamp(LineValidationType.ANIMATION_MAIN, imageInfo, option);
     const isValid = Object.values(result).every((r) => r === undefined);
     if (!isValid) {
       console.warn(result);
@@ -25,14 +26,12 @@ describe('test linestamp validation', () => {
   });
 
   test('should pass for max animation main', () => {
+    const imageInfo = {width: 240, height: 240, length: 20};
     const option: AnimationImageOptions = new AnimationImageOptions();
     option.imageExportMode = ImageExportMode.LINE;
     option.fps = 20;
     option.loop = 4;
-    option.imageInfo.width = 240;
-    option.imageInfo.height = 240;
-    option.imageInfo.length = 20;
-    const result = validateLineStamp(LineValidationType.ANIMATION_MAIN, option, {size: 300 * 1024});
+    const result = validateLineStamp(LineValidationType.ANIMATION_MAIN, imageInfo, option, {size: 300 * 1024});
     const isValid = Object.values(result).every((r) => r === undefined);
     if (!isValid) {
       console.warn(result);
@@ -43,15 +42,14 @@ describe('test linestamp validation', () => {
   // アニメーションスタンプ スタンプ
 
   test('should pass for min animation stamp', () => {
+    const imageInfo = {width: 270, height: 270, length: 5};
     const option: AnimationImageOptions = new AnimationImageOptions();
     option.imageExportMode = ImageExportMode.LINE;
     option.fps = 5;
     option.loop = 1;
-    option.imageInfo.width = 270;
-    option.imageInfo.height = 270;
-    option.imageInfo.length = 5;
     const result = validateLineStamp(
       LineValidationType.ANIMATION_STAMP,
+      imageInfo,
       option
     );
     const isValid = Object.values(result).every((r) => r === undefined);
@@ -62,16 +60,14 @@ describe('test linestamp validation', () => {
   });
 
   test('should pass for max animation stamp', () => {
+    const imageInfo = {width: 320, height: 270, length: 20};
     const option: AnimationImageOptions = new AnimationImageOptions();
     option.imageExportMode = ImageExportMode.LINE;
     option.fps = 20;
     option.loop = 4;
-    option.imageInfo.width = 320;
-    option.imageInfo.height = 270;
-    option.imageInfo.length = 20;
     const result = validateLineStamp(
       LineValidationType.ANIMATION_STAMP,
-      option, {size: 300 * 1024}
+      imageInfo, option, {size: 300 * 1024}
     );
     const isValid = Object.values(result).every((r) => r === undefined);
     if (!isValid) {
@@ -83,14 +79,12 @@ describe('test linestamp validation', () => {
   // エフェクトスタンプ
 
   test('should pass for min effect stamp', () => {
+    const imageInfo = {width: 200, height: 480, length: 5};
     const option: AnimationImageOptions = new AnimationImageOptions();
     option.imageExportMode = ImageExportMode.LINE;
     option.fps = 5;
     option.loop = 1;
-    option.imageInfo.width = 200;
-    option.imageInfo.height = 480;
-    option.imageInfo.length = 5;
-    const result = validateLineStamp(LineValidationType.EFFECT, option, {size: 500 * 1024});
+    const result = validateLineStamp(LineValidationType.EFFECT, imageInfo, option, {size: 500 * 1024});
     const isValid = Object.values(result).every((r) => r === undefined);
     if (!isValid) {
       console.warn(result);
@@ -99,14 +93,12 @@ describe('test linestamp validation', () => {
   });
 
   test('should pass for max effect stamp', () => {
+    const imageInfo = {width: 480, height: 480, length: 20};
     const option: AnimationImageOptions = new AnimationImageOptions();
     option.imageExportMode = ImageExportMode.LINE;
     option.fps = 20;
     option.loop = 3;
-    option.imageInfo.width = 480;
-    option.imageInfo.height = 480;
-    option.imageInfo.length = 20;
-    const result = validateLineStamp(LineValidationType.EFFECT, option);
+    const result = validateLineStamp(LineValidationType.EFFECT, imageInfo, option);
     const isValid = Object.values(result).every((r) => r === undefined);
     if (!isValid) {
       console.warn(result);
@@ -117,14 +109,12 @@ describe('test linestamp validation', () => {
   // ポップアップスタンプ
 
   test('should pass for min popup stamp', () => {
+    const imageInfo = {width: 200, height: 480, length: 5};
     const option: AnimationImageOptions = new AnimationImageOptions();
     option.imageExportMode = ImageExportMode.LINE;
     option.fps = 5;
     option.loop = 1;
-    option.imageInfo.width = 200;
-    option.imageInfo.height = 480;
-    option.imageInfo.length = 5;
-    const result = validateLineStamp(LineValidationType.POPUP, option, {size: 500 * 1024});
+    const result = validateLineStamp(LineValidationType.POPUP, imageInfo, option, {size: 500 * 1024});
     const isValid = Object.values(result).every((r) => r === undefined);
     if (!isValid) {
       console.warn(result);
@@ -133,14 +123,12 @@ describe('test linestamp validation', () => {
   });
 
   test('should pass for max popup stamp', () => {
+    const imageInfo = {width: 480, height: 480, length: 20};
     const option: AnimationImageOptions = new AnimationImageOptions();
     option.imageExportMode = ImageExportMode.LINE;
     option.fps = 20;
     option.loop = 3;
-    option.imageInfo.width = 480;
-    option.imageInfo.height = 480;
-    option.imageInfo.length = 20;
-    const result = validateLineStamp(LineValidationType.POPUP, option);
+    const result = validateLineStamp(LineValidationType.POPUP, imageInfo, option);
     const isValid = Object.values(result).every((r) => r === undefined);
     if (!isValid) {
       console.warn(result);
@@ -151,14 +139,12 @@ describe('test linestamp validation', () => {
   // アニメーション絵文字
 
   test('should pass for min emoji', () => {
+    const imageInfo = {width: 180, height: 180, length: 5};
     const option: AnimationImageOptions = new AnimationImageOptions();
     option.imageExportMode = ImageExportMode.LINE;
     option.fps = 5;
     option.loop = 1;
-    option.imageInfo.width = 180;
-    option.imageInfo.height = 180;
-    option.imageInfo.length = 5;
-    const result = validateLineStamp(LineValidationType.EMOJI, option, {size: 300 * 1024});
+    const result = validateLineStamp(LineValidationType.EMOJI, imageInfo, option, {size: 300 * 1024});
     const isValid = Object.values(result).every((r) => r === undefined);
     if (!isValid) {
       console.warn(result);
@@ -167,14 +153,12 @@ describe('test linestamp validation', () => {
   });
 
   test('should pass for max emoji', () => {
+    const imageInfo = {width: 180, height: 180, length: 20};
     const option: AnimationImageOptions = new AnimationImageOptions();
     option.imageExportMode = ImageExportMode.LINE;
     option.fps = 20;
     option.loop = 4;
-    option.imageInfo.width = 180;
-    option.imageInfo.height = 180;
-    option.imageInfo.length = 20;
-    const result = validateLineStamp(LineValidationType.EMOJI, option);
+    const result = validateLineStamp(LineValidationType.EMOJI, imageInfo, option);
     const isValid = Object.values(result).every((r) => r === undefined);
     if (!isValid) {
       console.warn(result);

--- a/product/common-src/validators/validateLineStamp.ts
+++ b/product/common-src/validators/validateLineStamp.ts
@@ -1,4 +1,5 @@
 import { AnimationImageOptions } from '../data/animation-image-option';
+import { ImageInfo } from '../data/image-info';
 import { ImageValidatorResult } from '../type/ImageValidator';
 import { LineValidationType } from '../type/LineValidationType';
 import { lineImageValidators } from './lineImageValidators';
@@ -8,6 +9,7 @@ import { lineImageValidators } from './lineImageValidators';
  */
 export const validateLineStamp = (
   validationType: LineValidationType,
+  imageInfo: ImageInfo,
   options: AnimationImageOptions,
   stat?: { size: number }
 ): ImageValidatorResult => {
@@ -15,14 +17,14 @@ export const validateLineStamp = (
 
   return {
     fileSizeError: stat ? validator.getFileSizeError(stat.size) : undefined,
-    frameCountError: validator.getFrameCountError(options.imageInfo.length),
+    frameCountError: validator.getFrameCountError(imageInfo.length),
     loopCountError: validator.getLoopCountError(options.loop),
     durationError: validator.getDurationError(
-      (options.imageInfo.length / options.fps) * options.loop
+      (imageInfo.length / options.fps) * options.loop
     ),
     imageSizeError: validator.getImageSizeError(
-      options.imageInfo.width,
-      options.imageInfo.height
+      imageInfo.width,
+      imageInfo.height
     )
   };
 };

--- a/product/main-src/file.ts
+++ b/product/main-src/file.ts
@@ -13,6 +13,7 @@ import { existsPath } from './fileFunctions/existsPath';
 import { localeData } from './locale-manager';
 import { notNull } from './utils/notNull';
 import { LineValidationType } from '../common-src/type/LineValidationType';
+import { ImageInfo } from '../common-src/data/image-info';
 export default class File {
   constructor(
     mainWindow: BrowserWindow,
@@ -34,6 +35,7 @@ export default class File {
   public async exec(
     temporaryPath: string,
     version: string,
+    imageInfo: ImageInfo,
     itemList: ImageData[],
     animationOptionData: AnimationImageOptions,
     validationType: LineValidationType
@@ -43,6 +45,7 @@ export default class File {
 
     // 出力処理を実行
     const result = await execGenerate(
+      imageInfo,
       itemList,
       animationOptionData,
       this.appPath,
@@ -58,6 +61,7 @@ export default class File {
       await this.validateLineStamp(
         validationType,
         result.pngPath,
+        imageInfo,
         animationOptionData
       );
     }
@@ -90,13 +94,19 @@ export default class File {
   private async validateLineStamp(
     validationType: LineValidationType,
     exportFilePath: string,
+    imageInfo: ImageInfo,
     animationOptionData: AnimationImageOptions
   ) {
     if (!existsPath(exportFilePath)) {
       return;
     }
     const stat = fs.statSync(exportFilePath);
-    const result = validateLineStamp(validationType, animationOptionData, stat);
+    const result = validateLineStamp(
+      validationType,
+      imageInfo,
+      animationOptionData,
+      stat
+    );
     const errors = [
       result.fileSizeError,
       result.frameCountError,

--- a/product/main-src/generators/execGenerate.ts
+++ b/product/main-src/generators/execGenerate.ts
@@ -11,6 +11,7 @@ import { generateHtml } from './generateHtml';
 import { shell } from 'electron';
 import { GenetateError } from './GenerateError';
 import { SaveDialog } from '../dialog/SaveDialog';
+import { ImageInfo } from '../../common-src/data/image-info';
 
 interface GenerateResult {
   error?: GenetateError;
@@ -38,6 +39,7 @@ const findMissingItemFile = (itemList: ImageData[]): ImageData | undefined =>
   itemList.find((item) => !fs.existsSync(item.imagePath));
 
 export const execGenerate = async (
+  imageInfo: ImageInfo,
   itemList: ImageData[],
   animationOptionData: AnimationImageOptions,
   appPath: string,
@@ -170,6 +172,7 @@ export const execGenerate = async (
           path.relative(selectedHTMLDirectoryPath, selectedWebPPath);
         generateHtml(
           selectedHTMLPath,
+          imageInfo,
           animationOptionData,
           relativePNGName,
           relativeWebPName

--- a/product/main-src/generators/generateHtml.ts
+++ b/product/main-src/generators/generateHtml.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import { AnimationImageOptions } from '../../common-src/data/animation-image-option';
 import { localeData } from '../locale-manager';
+import { ImageInfo } from '../../common-src/data/image-info';
 
 const createImageElementApng = (
   filePNGName: string,
@@ -62,6 +63,7 @@ const createImageElementWebpAndApng = (
 /* tslint:disable:quotemark */
 export const generateHtml = (
   exportFilePath: string,
+  imageInfo: ImageInfo,
   optionData: AnimationImageOptions,
   filePNGName?: string,
   fileWebPName?: string
@@ -71,7 +73,7 @@ export const generateHtml = (
   const isIncludeApng = optionData.enabledExportApng && filePNGName;
   const isIncludeWebP = optionData.enabledExportWebp && fileWebPName;
 
-  const { width, height } = optionData.imageInfo;
+  const { width, height } = imageInfo;
   if (isIncludeApng && isIncludeWebP) {
     imageElement = createImageElementWebpAndApng(
       fileWebPName,

--- a/product/main-src/main.ts
+++ b/product/main-src/main.ts
@@ -19,6 +19,7 @@ import { sendError } from './error/send-error';
 import { AppConfig } from '../common-src/config/app-config';
 import { localeData } from './locale-manager';
 import { LineValidationType } from '../common-src/type/LineValidationType';
+import { ImageInfo } from '../common-src/data/image-info';
 
 // アプリケーション作成用のモジュールを読み込み
 const errorMessage = new ErrorMessage();
@@ -161,6 +162,7 @@ handle(
   async (
     event,
     version: string,
+    imageInfo: ImageInfo,
     itemList: ImageData[],
     animationOptionData: AnimationImageOptions,
     validationType: LineValidationType
@@ -176,6 +178,7 @@ handle(
       .exec(
         app.getPath('temp'),
         version,
+        imageInfo,
         itemList,
         animationOptionData,
         validationType

--- a/product/src/app/components/anim-preview/anim-preview.html
+++ b/product/src/app/components/anim-preview/anim-preview.html
@@ -24,9 +24,7 @@
           'badge-success': !validationErrors.imageSizeError,
           'badge-danger': validationErrors.imageSizeError
         }"
-        >W{{ animationOptionData.imageInfo.width }}×H{{
-          animationOptionData.imageInfo.height
-        }}px</span
+        >W{{ imageInfo.width }}×H{{ imageInfo.height }}px</span
       >
     </span>
     <span class="ml-2">/</span>
@@ -38,7 +36,7 @@
           'badge-success': !validationErrors.frameCountError,
           'badge-danger': validationErrors.frameCountError
         }"
-        >{{ items.length }}</span
+        >{{ imageInfo.length }}</span
       ></span
     >
     <span class="ml-2" *ngIf="animationOptionData.noLoop === false">/</span>

--- a/product/src/app/components/anim-preview/anim-preview.ts
+++ b/product/src/app/components/anim-preview/anim-preview.ts
@@ -25,6 +25,7 @@ import {
 } from '../../../../common-src/type/ImageValidator';
 import { LineValidationType } from '../../../../common-src/type/LineValidationType';
 import { Tooltip } from '../../../../common-src/type/TooltipType';
+import { ImageInfo } from '../../../../common-src/data/image-info';
 
 @Component({
   selector: 'app-anim-preview',
@@ -37,6 +38,9 @@ import { Tooltip } from '../../../../common-src/type/TooltipType';
 export class AnimPreviewComponent implements OnChanges, OnInit {
   @Input()
   animationOptionData = new AnimationImageOptions();
+
+  @Input()
+  imageInfo = new ImageInfo();
 
   @Input()
   items: ImageData[] = [];
@@ -143,6 +147,7 @@ export class AnimPreviewComponent implements OnChanges, OnInit {
     if (this.animationOptionData.imageExportMode === ImageExportMode.LINE) {
       this.validationErrors = validateLineStamp(
         this.checkRule,
+        this.imageInfo,
         this.animationOptionData
       );
     } else {

--- a/product/src/app/components/app/app.html
+++ b/product/src/app/components/app/app.html
@@ -69,6 +69,7 @@
   <!-- アニメーションプレビュー画面 -->
   <div class="mod-preview bg-dark text-white">
     <app-anim-preview
+      [imageInfo]="imageInfo"
       [animationOptionData]="animationOptionData"
       [items]="items"
       [checkRule]="checkRule.value"

--- a/product/src/app/components/app/app.ts
+++ b/product/src/app/components/app/app.ts
@@ -25,6 +25,7 @@ import {
   ImageValidatorResult,
   ValidationResult
 } from '../../../../common-src/type/ImageValidator';
+import { ImageInfo } from '../../../../common-src/data/image-info';
 
 const getFirstNumber = (text: string): number | undefined => {
   const numStr = text.match(/\d+/g)?.pop();
@@ -64,6 +65,12 @@ export class AppComponent implements OnInit, AfterViewInit {
     y: 0
   };
   checkRule = new UntypedFormControl(LineValidationType.ANIMATION_STAMP);
+
+  imageInfo: ImageInfo = {
+    width: 0,
+    height: 0,
+    length: 0
+  };
 
   readonly checkRuleList = checkRuleList;
   readonly checkRuleLabel = {
@@ -202,6 +209,7 @@ export class AppComponent implements OnInit, AfterViewInit {
     try {
       await this.ipcService.exec(
         AppConfig.version,
+        this.imageInfo,
         this.items,
         this.animationOptionData,
         this.checkRule.value
@@ -286,7 +294,7 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.numbering();
     if (items.length >= 1) {
       await this.checkImageSize(items);
-      this.animationOptionData.imageInfo.length = items.length;
+      this.imageInfo.length = items.length;
     }
     this.isImageSelected = this.items.length >= 1;
   }
@@ -303,8 +311,9 @@ export class AppComponent implements OnInit, AfterViewInit {
       // サイズが取れなかったら何もしない
       return;
     }
-    this.animationOptionData.imageInfo.width = baseSize.w;
-    this.animationOptionData.imageInfo.height = baseSize.h;
+
+    this.imageInfo.width = baseSize.w;
+    this.imageInfo.height = baseSize.h;
     if (errorItem) {
       // 不一致ならエラーフラグを立てた上でエラーメッセージを表示
       this.apngFileSizeError = true;

--- a/product/src/app/process/ipc.service.ts
+++ b/product/src/app/process/ipc.service.ts
@@ -3,6 +3,7 @@ import { IpcId, IpcInvoke } from '../../../common-src/ipc-id';
 import { AnimationImageOptions } from '../../../common-src/data/animation-image-option';
 import { ImageData } from '../../../common-src/data/image-data';
 import { LineValidationType } from '../../../common-src/type/LineValidationType';
+import { ImageInfo } from '../../../common-src/data/image-info';
 
 interface IElectronAPI {
   invoke: IpcInvoke;
@@ -55,6 +56,7 @@ export default class IpcService {
   /** 画像の変換・保存処理を実行します */
   exec(
     version: string,
+    imageInfo: ImageInfo,
     itemList: ImageData[],
     animationOptionData: AnimationImageOptions,
     validationType: LineValidationType
@@ -62,6 +64,7 @@ export default class IpcService {
     return this.electronApi.invoke(
       IpcId.EXEC_IMAGE_EXPORT_PROCESS,
       version,
+      imageInfo,
       itemList,
       animationOptionData,
       validationType


### PR DESCRIPTION
### 対応内容
- AnimationImageOptionからimageInfoを別にし、セーブ・ロードからの影響をなくす

### デバッグ項目
#### 設定データが存在しない状態からの動作チェック
1. v4.3を初回起動
2. 用途をWebページ用に切り替える
3. ラインスタンプ画像として適切な画像をドロップ
4. 用途をLINE用に切り替える
→ フレームサイズが0x0と判定されず、(3)と同一のサイズになること
→ 総フレーム数が「ループ回数×(3)でドロップした画像枚数」になること
→ フレームサイズがエラー表示（背景赤色）にならないこと
→ 画像保存時にバリデーションエラーが発生しないこと

#### 設定データが存在する場合の動作チェック
1. v4.3を起動
2. 用途をLINEページ用に切り替える
3. 任意の画像をドロップ
4. 用途をWebページ用に切り替える
5. 3とは別の幅・高さの画像をドロップ
6. 用途をLINE用に切り替える
→ フレームサイズが(3)の状態にならず、(5)と同一になること
→ 総フレーム数が「ループ回数×(5)でドロップした画像枚数」になること

#### HTMLの出力が正しいかの動作チェック
1. v4.3を起動
2. 用途をWebページ用に切り替える
3. 任意の画像をドロップ
4. 用途をLINE用に切り替える
5. 3とは別の幅・高さの画像をドロップ
6. 用途をWebページ用に切り替える
→ フレームサイズが(3)の状態にならず、(5)と同一になること
→ 総フレーム数が「ループ回数×(5)でドロップした画像枚数」になること
7. HTMLを出力する
→ HTMLに出力されたwidth,heightが(5)でドロップした画像サイズになること